### PR TITLE
fix: add Inventory Quantity Detail GI (Enhancement #43334182789)

### DIFF
--- a/Customization/_project/project.xml
+++ b/Customization/_project/project.xml
@@ -666,4 +666,252 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('SOOrder') 
             </Children>
         </PXGridLevel>
     </Page>
+    <Inquiry ScreenID="GI.00.70.00" DisplayName="Inventory Quantity Detail">
+        <Tables>
+            <Table Alias="InventoryItem" Name="InventoryItem" />
+            <Table Alias="INSiteStatus" Name="INSiteStatus" />
+            <Table Alias="TemplateItem" Name="InventoryItem" />
+            <Table Alias="POVendorInventory" Name="POVendorInventory" />
+            <Table Alias="WMSTLVendorLeadTimes" Name="WMSTLVendorLeadTimes" />
+            <Table Alias="POOrder" Name="POOrder" />
+            <Table Alias="POLine" Name="POLine" />
+            <Table Alias="IGCMPOLandedCost" Name="IGCMPOLandedCost" />
+            <Table Alias="IGCMPOLandedCostLine" Name="IGCMPOLandedCostLine" />
+        </Tables>
+        <Relations>
+            <Relation>
+                <ParentTable>InventoryItem</ParentTable>
+                <ChildTable>INSiteStatus</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>InventoryID</ParentField>
+                        <ChildField>InventoryID</ChildField>
+                    </Link>
+                </Links>
+                <Conditions>
+                    <Condition>
+                        <Field>SiteID</Field>
+                        <Condition>Equal</Condition>
+                        <Value>99</Value>
+                    </Condition>
+                </Conditions>
+            </Relation>
+            <Relation>
+                <ParentTable>InventoryItem</ParentTable>
+                <ChildTable>TemplateItem</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>TemplateItemID</ParentField>
+                        <ChildField>InventoryID</ChildField>
+                    </Link>
+                </Links>
+            </Relation>
+            <Relation>
+                <ParentTable>InventoryItem</ParentTable>
+                <ChildTable>POVendorInventory</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>InventoryID</ParentField>
+                        <ChildField>InventoryID</ChildField>
+                    </Link>
+                </Links>
+                <Conditions>
+                    <Condition>
+                        <Field>IsDefault</Field>
+                        <Condition>Equal</Condition>
+                        <Value>true</Value>
+                    </Condition>
+                </Conditions>
+            </Relation>
+            <Relation>
+                <ParentTable>InventoryItem</ParentTable>
+                <ChildTable>WMSTLVendorLeadTimes</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>InventoryID</ParentField>
+                        <ChildField>InventoryID</ChildField>
+                    </Link>
+                </Links>
+            </Relation>
+            <Relation>
+                <ParentTable>InventoryItem</ParentTable>
+                <ChildTable>POLine</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>InventoryID</ParentField>
+                        <ChildField>InventoryID</ChildField>
+                    </Link>
+                </Links>
+                <Conditions>
+                    <Condition>
+                        <Field>OpenQty</Field>
+                        <Condition>Greater</Condition>
+                        <Value>0</Value>
+                    </Condition>
+                </Conditions>
+            </Relation>
+            <Relation>
+                <ParentTable>POLine</ParentTable>
+                <ChildTable>POOrder</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>OrderType</ParentField>
+                        <ChildField>OrderType</ChildField>
+                    </Link>
+                    <Link>
+                        <ParentField>OrderNbr</ParentField>
+                        <ChildField>OrderNbr</ChildField>
+                    </Link>
+                </Links>
+                <Conditions>
+                    <Condition>
+                        <Field>Status</Field>
+                        <Condition>In</Condition>
+                        <Value>N,O</Value>
+                    </Condition>
+                </Conditions>
+            </Relation>
+            <Relation>
+                <ParentTable>POLine</ParentTable>
+                <ChildTable>IGCMPOLandedCostLine</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>OrderType</ParentField>
+                        <ChildField>POOrderType</ChildField>
+                    </Link>
+                    <Link>
+                        <ParentField>OrderNbr</ParentField>
+                        <ChildField>PONbr</ChildField>
+                    </Link>
+                    <Link>
+                        <ParentField>LineNbr</ParentField>
+                        <ChildField>POLineNbr</ChildField>
+                    </Link>
+                </Links>
+            </Relation>
+            <Relation>
+                <ParentTable>IGCMPOLandedCostLine</ParentTable>
+                <ChildTable>IGCMPOLandedCost</ChildTable>
+                <JoinType>LEFT</JoinType>
+                <Links>
+                    <Link>
+                        <ParentField>RefNbr</ParentField>
+                        <ChildField>RefNbr</ChildField>
+                    </Link>
+                </Links>
+            </Relation>
+        </Relations>
+        <Wheres>
+            <Where>
+                <Field>InventoryItem.StkItem</Field>
+                <Condition>Equal</Condition>
+                <Value>1</Value>
+            </Where>
+        </Wheres>
+        <Fields>
+            <Field>
+                <Name>InventoryCD</Name>
+                <Alias>StockItemSKU</Alias>
+                <Table>InventoryItem</Table>
+                <DisplayName>Stock Item SKU</DisplayName>
+            </Field>
+            <Field>
+                <Name>Descr</Name>
+                <Alias>StockItemDescription</Alias>
+                <Table>InventoryItem</Table>
+                <DisplayName>Stock Item Description</DisplayName>
+            </Field>
+            <Field>
+                <Name>Descr</Name>
+                <Alias>TemplateDescription</Alias>
+                <Table>TemplateItem</Table>
+                <DisplayName>Template ID Description</DisplayName>
+            </Field>
+            <Field>
+                <Name>QtyAvail</Name>
+                <Alias>QtyAvailForShipping</Alias>
+                <Table>INSiteStatus</Table>
+                <DisplayName>Quantity Available for Shipping</DisplayName>
+            </Field>
+            <Field>
+                <Name>QtyOnHand</Name>
+                <Alias>QtyOnHand</Alias>
+                <Table>INSiteStatus</Table>
+                <DisplayName>Quantity on Hand</DisplayName>
+            </Field>
+            <Field>
+                <Name>ItemStatus</Name>
+                <Alias>StockItemStatus</Alias>
+                <Table>InventoryItem</Table>
+                <DisplayName>Stock Item Status</DisplayName>
+            </Field>
+            <Field>
+                <Name>VendorID</Name>
+                <Alias>Vendor</Alias>
+                <Table>POVendorInventory</Table>
+                <DisplayName>Vendor</DisplayName>
+            </Field>
+            <Field>
+                <Name>LeadTimeDays</Name>
+                <Alias>VendorLeadTime</Alias>
+                <Table>WMSTLVendorLeadTimes</Table>
+                <DisplayName>Vendor Lead Time</DisplayName>
+            </Field>
+            <Field>
+                <Name>AddLeadTimeDays</Name>
+                <Alias>VendorLeadTimeFallback</Alias>
+                <Table>POVendorInventory</Table>
+                <DisplayName>Vendor Lead Time (Fallback)</DisplayName>
+            </Field>
+            <Field>
+                <Name>CountryOfOrigin</Name>
+                <Alias>CountryOfOrigin</Alias>
+                <Table>InventoryItem</Table>
+                <DisplayName>Country of Origin</DisplayName>
+            </Field>
+            <Field>
+                <Name>OrderNbr</Name>
+                <Alias>PONumber</Alias>
+                <Table>POOrder</Table>
+                <DisplayName>PO Number</DisplayName>
+            </Field>
+            <Field>
+                <Name>OpenQty</Name>
+                <Alias>OpenQuantityOnPO</Alias>
+                <Table>POLine</Table>
+                <DisplayName>Open Quantity on PO</DisplayName>
+            </Field>
+            <Field>
+                <Name>UsrExpArrivalDate</Name>
+                <Alias>POExpectedArrivalDate</Alias>
+                <Table>POLine</Table>
+                <DisplayName>PO Expected Arrival Date</DisplayName>
+            </Field>
+            <Field>
+                <Name>ContainerNbr</Name>
+                <Alias>ContainerNumber</Alias>
+                <Table>IGCMPOLandedCostLine</Table>
+                <DisplayName>Container Number</DisplayName>
+            </Field>
+            <Field>
+                <Name>RefNbr</Name>
+                <Alias>ContainerTransNumber</Alias>
+                <Table>IGCMPOLandedCost</Table>
+                <DisplayName>Container Trans Number</DisplayName>
+            </Field>
+        </Fields>
+        <Sortings>
+            <Sorting>
+                <Field>InventoryCD</Field>
+                <SortOrder>Ascending</SortOrder>
+            </Sorting>
+        </Sortings>
+    </Inquiry>
 </Customization>


### PR DESCRIPTION
## Summary
- Adds the Inventory Quantity Detail GI (screen ID GI.00.70.00) to the CI/CD-managed customization project
- AcuDev previously deployed this directly via Customization API but it wasn't in the repo
- Added `StkItem=1` WHERE filter to show only stock items (was missing)
- All joins are LEFT to ensure items with zero inventory still appear
- Fixes SKU 31759 and 40231 not being visible (reported by Sarah)

## Context
Enhancement ticket 43334182789. AcuDev deployed after 8 retries but the GI still had issues. The reply interceptor is now live to catch feedback replies going forward.

## Test plan
- [ ] Verify GI deploys successfully via CI/CD publish
- [ ] Search for SKU 31759 in the GI — must appear
- [ ] Search for SKU 40231 in the GI — must appear
- [ ] Verify items with open POs show PO data
- [ ] Verify items without inventory show zero/blank quantities (not missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)