### PR TITLE
feat(AesthetikContainers): POOrder DRP Phase 0 lead-time fields (P0-B.1)

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -25,6 +25,22 @@
                         <Prop Key="DataField" Value="UsrActArrivalDate" />
                     </PXDateTimeEdit>
                 </AddItem>
+                <AddItem>
+                    <PXDateTimeEdit TypeFullName="PX.Web.UI.PXDateTimeEdit">
+                        <Prop Key="Virtual:ApplyStylesheetSkin" />
+                        <Prop Key="ID" Value="edUsrAcknowledgedDate" />
+                        <Prop Key="DataField" Value="UsrAcknowledgedDate" />
+                        <Prop Key="CommitChanges" Value="True" />
+                    </PXDateTimeEdit>
+                </AddItem>
+                <AddItem>
+                    <PXDateTimeEdit TypeFullName="PX.Web.UI.PXDateTimeEdit">
+                        <Prop Key="Virtual:ApplyStylesheetSkin" />
+                        <Prop Key="ID" Value="edUsrFactoryReadyDate" />
+                        <Prop Key="DataField" Value="UsrFactoryReadyDate" />
+                        <Prop Key="CommitChanges" Value="True" />
+                    </PXDateTimeEdit>
+                </AddItem>
             </Children>
         </PXFormView>
         <PXGridLevel DataMember="Transactions" ParentId="phG_tab_Items#0_grid_Levels#0" TypeFullName="PX.Web.UI.PXGridLevel">

--- a/src/StudioB.Containers/Extensions/POOrderExt.cs
+++ b/src/StudioB.Containers/Extensions/POOrderExt.cs
@@ -26,5 +26,17 @@ namespace StudioB.Containers
         [PXUIField(DisplayName = "Container / BOL Ref")]
         public string UsrContainerRef { get; set; }
         #endregion
+        #region UsrAcknowledgedDate
+        public abstract class usrAcknowledgedDate : BqlDateTime.Field<usrAcknowledgedDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Vendor Acknowledged Date")]
+        public DateTime? UsrAcknowledgedDate { get; set; }
+        #endregion
+        #region UsrFactoryReadyDate
+        public abstract class usrFactoryReadyDate : BqlDateTime.Field<usrFactoryReadyDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Factory Ready Date")]
+        public DateTime? UsrFactoryReadyDate { get; set; }
+        #endregion
     }
 }

--- a/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
+++ b/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
@@ -226,6 +226,15 @@ namespace StudioB.Containers
                     EnsureColumn(conn, "POReceiptLine", "UsrActualFreightAmt", "decimal(25,4) NULL");
                     EnsureColumn(conn, "POReceiptLine", "UsrBrokerageAmt", "decimal(25,4) NULL");
 
+                    // ── POOrder DRP Phase 0 lead-time tracking fields ──────────
+                    // UsrAcknowledgedDate / UsrFactoryReadyDate populated by
+                    // vendor acknowledgment email watcher (webhook-router)
+                    // and by Vendor Planning Hub manual entry. Consumed by
+                    // drp_lead_time_samples → vendor lead-time learning.
+                    // See docs/plans/2026-04-09-drp-implementation-design.md §4.2.
+                    EnsureColumn(conn, "POOrder", "UsrAcknowledgedDate", "datetime NULL");
+                    EnsureColumn(conn, "POOrder", "UsrFactoryReadyDate", "datetime NULL");
+
                     // ── Freight Forwarders Table ──────────────────────────────
                     EnsureTable(conn, "UsrFreightForwarder", @"
                         CompanyID int NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary

Adds `POOrder.UsrAcknowledgedDate` and `POOrder.UsrFactoryReadyDate` (both `PXDBDate`, nullable) to the `AesthetikContainers` customization. Implements DRP Phase 0 workstream **P0-B.1**.

These fields feed `drp_lead_time_samples` via:
1. `webhook-router/src/workers/po-email-watcher.ts` (vendor acknowledgment email parsing — workstream 4.8)
2. Vendor Planning Hub manual entry
3. Human updates directly on PO301000

Together with existing `UsrExpArrivalDate` / `UsrActArrivalDate`, they enable the 4-stage lead-time decomposition: `ack_lag` → `production` → `transit` → `total`.

## Changes

| File | Change |
|---|---|
| `src/StudioB.Containers/Extensions/POOrderExt.cs` | Two new `PXDBDate` properties with BQL field classes |
| `src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs` | Two `EnsureColumn` calls in `UpdateDatabase()` (idempotent `IF NOT EXISTS` ALTER pattern — same as existing POReceiptLine/InventoryItem adds) |
| `Customization/AesthetikContainers/project.xml` | Two `PXDateTimeEdit` `AddItem` entries on the PO301000 form with `CommitChanges=True` |

## Design reference

`docs/plans/2026-04-09-drp-implementation-design.md` §4.2 — Acumatica custom fields (P0-B.1), DAC layout in §5.1.

## Why `EnsureColumn` and not `<Sql>`

`AesthetikContainers` uses the `CustomizationPlugin` DDL pattern (`AesthetikContainersInstall.UpdateDatabase()`) not `<Sql>` tags. Both are SAFE per `memory/context/lessons-learned.md` — the plugin avoids the banned `WebConfigurationManager` and uses `ConfigurationManager["ProjectX"]`. Matching the package's existing idempotent ALTER style keeps the install runner authoritative for schema.

## Deploy plan

- Embargoed until **18:00 ET** (workflow `force_business_hours=false` gate). Task P0-B.1 flagged "off-hours only" in project plan.
- CI on this PR runs **validate-only** (PR trigger skips publish).
- After PR merge, deploy via `workflow_dispatch → production` after 18:00 ET.
- **Verification:** open PO301000 against prod, confirm both date pickers render on the form and save-round-trip works on a draft PO. API read-back via `acumatica_get_schema PurchaseOrder` to confirm DAC field visibility.

## Test plan

- [ ] CI build + acuminator job passes (DLL rebuild picks up new fields)
- [ ] CI qualify job passes
- [ ] After 18:00 ET: workflow_dispatch deploy to production succeeds
- [ ] PO301000 loads with both new date pickers visible
- [ ] Save round-trip on a draft PO persists both dates
- [ ] `acumatica_get_schema PurchaseOrder` shows `UsrAcknowledgedDate` and `UsrFactoryReadyDate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)