### PR TITLE
feat(drp): P0-A.3 DRP_OpenPOLines GI (SB401100)

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -2436,6 +2436,189 @@ public partial class Page_SB_SB302040 : PXPage
     </data>
   </data-set>
 </GenericInquiryScreen>
+    <GenericInquiryScreen>
+  <data-set>
+                <relations format-version="3" relations-version="20240201" main-table="GIDesign" stable-sharing="True" file-name="(Name)">
+    <link from="GIFilter (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GIGroupBy (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GIMassAction (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GIMassUpdateField (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GINavigationScreen (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GINavigationParameter (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
+    <link from="GINavigationCondition (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
+    <link from="GIOn (DesignID, RelationNbr)" to="GIRelation (DesignID, LineNbr)" />
+    <link from="GIRecordDefault (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GIRelation (DesignID, ParentTable)" to="GITable (DesignID, Alias)" />
+    <link from="GIRelation (DesignID, ChildTable)" to="GITable (DesignID, Alias)" />
+    <link from="GIResult (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GIResult (ObjectName, DesignID)" to="GITable (Alias, DesignID)" />
+    <link from="GISort (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GITable (DesignID)" to="GIDesign (DesignID)" />
+    <link from="GIWhere (DesignID)" to="GIDesign (DesignID)" />
+    <link from="SiteMap (Url)" to="GIDesign (DesignID)" type="WeakByUrl" linkname="toDesignById" baseurl="~/GenericInquiry/GenericInquiry.aspx" paramnames="id" />
+    <link from="SiteMap (Url)" to="GIDesign (Name)" type="WeakByUrl" linkname="toDesignByName" baseurl="~/GenericInquiry/GenericInquiry.aspx" />
+    <link from="ListEntryPoint (ListScreenID)" to="SiteMap (ScreenID)" />
+    <link from="SiteMap (ScreenID)" to="GIDesign (PrimaryScreenIDNew)" linkname="to1Screen" />
+    <link from="FilterHeader (ScreenID)" to="SiteMap (ScreenID)" />
+    <link from="FilterRow (FilterID)" to="FilterHeader (FilterID)" />
+    <link from="PivotTable (NoteID)" to="FilterHeader (RefNoteID)" />
+    <link from="PivotField (ScreenID, PivotTableID)" to="PivotTable (ScreenID, PivotTableID)" />
+    <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
+    <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
+    <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
+    <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
+    <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
+    <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
+    <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+    <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+    <link from="GIDesign (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIFilter (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIFilter (NoteID)" to="GIFilterKvExt (RecordID)" type="RowKvExt" />
+    <link from="GIGroupBy (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIOn (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIRelation (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIResult (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIResult (NoteID)" to="GIResultKvExt (RecordID)" type="RowKvExt" />
+    <link from="GISort (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GITable (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="GIWhere (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="FilterHeader (NoteID)" to="Note (NoteID)" type="Note" />
+    <link from="FilterHeader (NoteID)" to="FilterHeaderKvExt (RecordID)" type="RowKvExt" />
+</relations>
+            <layout>
+    <table name="GIDesign">
+        <table name="GIFilter" uplink="(DesignID) = (DesignID)">
+            <table name="Note" uplink="(NoteID) = (NoteID)" />
+            <table name="GIFilterKvExt" uplink="(NoteID) = (RecordID)" />
+        </table>
+        <table name="GIGroupBy" uplink="(DesignID) = (DesignID)">
+            <table name="Note" uplink="(NoteID) = (NoteID)" />
+        </table>
+        <table name="GIMassAction" uplink="(DesignID) = (DesignID)" />
+        <table name="GIMassUpdateField" uplink="(DesignID) = (DesignID)" />
+        <table name="GINavigationScreen" uplink="(DesignID) = (DesignID)">
+            <table name="GINavigationParameter" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
+            <table name="GINavigationCondition" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
+        </table>
+        <table name="GIRecordDefault" uplink="(DesignID) = (DesignID)" />
+        <table name="GISort" uplink="(DesignID) = (DesignID)">
+            <table name="Note" uplink="(NoteID) = (NoteID)" />
+        </table>
+        <table name="GITable" uplink="(DesignID) = (DesignID)">
+            <table name="GIRelation" uplink="(DesignID, Alias) = (DesignID, ParentTable)">
+                <table name="GIOn" uplink="(DesignID, LineNbr) = (DesignID, RelationNbr)">
+                    <table name="Note" uplink="(NoteID) = (NoteID)" />
+                </table>
+                <table name="Note" uplink="(NoteID) = (NoteID)" />
+            </table>
+            <table name="GIResult" uplink="(Alias, DesignID) = (ObjectName, DesignID)">
+                <table name="Note" uplink="(NoteID) = (NoteID)" />
+                <table name="GIResultKvExt" uplink="(NoteID) = (RecordID)" />
+            </table>
+            <table name="Note" uplink="(NoteID) = (NoteID)" />
+        </table>
+        <table name="GIWhere" uplink="(DesignID) = (DesignID)">
+            <table name="Note" uplink="(NoteID) = (NoteID)" />
+        </table>
+        <table name="SiteMap" uplink="(DesignID) = (Url)" linkname="toDesignById">
+            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
+            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
+                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
+                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
+                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
+                </table>
+                <table name="Note" uplink="(NoteID) = (NoteID)" />
+                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
+            </table>
+            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
+                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
+            </table>
+            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
+        </table>
+        <table name="SiteMap" uplink="(Name) = (Url)" linkname="toDesignByName">
+            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
+            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
+                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
+                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
+                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
+                </table>
+                <table name="Note" uplink="(NoteID) = (NoteID)" />
+                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
+            </table>
+            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
+                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
+            </table>
+            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
+        </table>
+        <table name="SiteMap" uplink="(PrimaryScreenIDNew) = (ScreenID)" linkname="to1Screen">
+            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
+            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
+                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
+                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
+                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
+                </table>
+                <table name="Note" uplink="(NoteID) = (NoteID)" />
+                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
+            </table>
+            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
+                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
+            </table>
+            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
+        </table>
+        <table name="Note" uplink="(NoteID) = (NoteID)" />
+    </table>
+</layout>
+    <data>
+      <GIDesign>
+        <row DesignID="89912975-c6ed-41ad-b514-a0f775a89362" Name="DRP_OpenPOLines" ScreenID="SB401100" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+          <GITable Alias="Line" Name="PX.Objects.PO.POLine">
+            <GIRelation LineNbr="1" ChildTable="POOrder" IsActive="1" JoinType="L">
+              <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
+              <GIOn LineNbr="2" ParentField="OrderNbr" Condition="E " ChildField="OrderNbr" Operation="A" />
+            </GIRelation>
+            <GIRelation LineNbr="2" ChildTable="ContainerLink" IsActive="1" JoinType="L">
+              <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
+              <GIOn LineNbr="2" ParentField="OrderNbr" Condition="E " ChildField="OrderNbr" Operation="A" />
+              <GIOn LineNbr="3" ParentField="LineNbr" Condition="E " ChildField="LineNbr" Operation="A" />
+            </GIRelation>
+            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="OrderType" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="PO Type" RowID="d708e601-603b-4976-a9d6-87995b39b562" />
+            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="OrderNbr" Width="100" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="PO Nbr" RowID="a4ca68b7-fd7c-4fc5-b2b9-37561a4b356e" />
+            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="LineNbr" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Line Nbr" RowID="3a6373a9-0922-4901-8364-dc3408bf9221" />
+            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="InventoryID" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="54ff852c-644c-484f-8cbe-0a01889b92ad" />
+            <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="VendorID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Vendor" RowID="f8643af1-993a-480b-90bb-d0110be7e72e" />
+            <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="OrderQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Order Qty" RowID="a249525f-f5a8-42cb-afb9-8ce335e331f0" />
+            <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="ReceivedQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Received" RowID="d1e7376f-f209-4d68-924e-5e6bff3d4d79" />
+            <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="OpenQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Open Qty" RowID="a7b6ebc5-24a5-4827-89fd-f3d1f1b70eec" />
+            <GIResult LineNbr="9" SortOrder="9" IsActive="1" Field="PromisedDate" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Promised Date" RowID="202a8b2e-87d7-4407-ae00-80a992b5686b" />
+          </GITable>
+          <GITable Alias="POOrder" Name="PX.Objects.PO.POOrder">
+            <GIResult LineNbr="10" SortOrder="10" IsActive="1" Field="UsrAcknowledgedDate" Width="110" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Vendor Ack'd" RowID="ccc39a8e-89cf-435f-8e39-c35ecd032bc6" />
+            <GIResult LineNbr="11" SortOrder="11" IsActive="1" Field="UsrFactoryReadyDate" Width="110" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Factory Ready" RowID="db94eb69-50b0-468b-ac76-81f3515ce171" />
+          </GITable>
+          <GITable Alias="ContainerLink" Name="StudioB.Containers.UsrContainerPOLink">
+            <GIRelation LineNbr="3" ChildTable="Container" IsActive="1" JoinType="L">
+              <GIOn LineNbr="1" ParentField="ContainerID" Condition="E " ChildField="ContainerID" Operation="A" />
+            </GIRelation>
+          </GITable>
+          <GITable Alias="Container" Name="StudioB.Containers.UsrContainer">
+            <GIResult LineNbr="12" SortOrder="12" IsActive="1" Field="ContainerCD" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Container Nbr" RowID="93ed61d7-5194-4c5e-9c2e-dc02f6a7059b" />
+          </GITable>
+          <GIWhere LineNbr="1" IsActive="1" DataFieldName="Line.LineType" Condition="E " IsExpression="0" Value1="GoodsForInventory" Operation="A" />
+          <GIWhere LineNbr="2" IsActive="1" DataFieldName="Line.OpenQty" Condition="G " IsExpression="0" Value1="0" Operation="A" />
+          <GIWhere LineNbr="3" OpenBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="N" Operation="A" />
+          <GIWhere LineNbr="4" CloseBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="O" Operation="O" />
+          <GISort LineNbr="1" IsActive="1" DataFieldName="Line.PromisedDate" SortOrder="A" />
+          <SiteMap linkname="toDesignById">
+            <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="660b0c64-b2bf-4848-a863-468f5ff34fbd" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
+              <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
+            </row>
+          </SiteMap>
+
+        </row>
+      </GIDesign>
+    </data>
+  </data-set>
+</GenericInquiryScreen>
     <ScreenWithRights AccessRightsMergeRule="ApplyAndKeep">
         <data-set>
             <relations format-version="3" relations-version="20240201" main-table="SiteMap">

--- a/scripts/build_drp_a3_gi.py
+++ b/scripts/build_drp_a3_gi.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Build the P0-A.3 DRP_OpenPOLines GI (SB401100) and splice it into
+Customization/AesthetikContainers/project.xml after the POContainers block.
+
+Depends on POOrder.UsrAcknowledgedDate and POOrder.UsrFactoryReadyDate
+being present in the compiled StudioB.Containers DLL (added by #311
+via POOrderExt.cs — merged to main as commit c03a48a).
+
+Idempotent: refuses to run if the target DesignID already exists.
+"""
+import sys
+import re
+from pathlib import Path
+
+WT = Path("/Users/kevin/dev/acumatica-ci-cd/.claude/worktrees/drp-a3-open-po-lines")
+PROJ = WT / "Customization/AesthetikContainers/project.xml"
+
+# UUIDs generated 2026-04-09
+A3_DESIGN = "89912975-c6ed-41ad-b514-a0f775a89362"
+A3_NODE   = "660b0c64-b2bf-4848-a863-468f5ff34fbd"
+A3_ROW = {
+    "POType":              "d708e601-603b-4976-a9d6-87995b39b562",
+    "POOrderNbr":          "a4ca68b7-fd7c-4fc5-b2b9-37561a4b356e",
+    "POLineNbr":           "3a6373a9-0922-4901-8364-dc3408bf9221",
+    "InventoryID":         "54ff852c-644c-484f-8cbe-0a01889b92ad",
+    "VendorID":            "f8643af1-993a-480b-90bb-d0110be7e72e",
+    "OrderQty":            "a249525f-f5a8-42cb-afb9-8ce335e331f0",
+    "ReceivedQty":         "d1e7376f-f209-4d68-924e-5e6bff3d4d79",
+    "OpenQty":             "a7b6ebc5-24a5-4827-89fd-f3d1f1b70eec",
+    "PromisedDate":        "202a8b2e-87d7-4407-ae00-80a992b5686b",
+    "UsrAcknowledgedDate": "ccc39a8e-89cf-435f-8e39-c35ecd032bc6",
+    "UsrFactoryReadyDate": "db94eb69-50b0-468b-ac76-81f3515ce171",
+    "ContainerNbr":        "93ed61d7-5194-4c5e-9c2e-dc02f6a7059b",
+}
+
+# Shared workspace identifiers (Container Tracking folder)
+PARENT_ID    = "9c89e3db-7c47-43c0-8554-5d2c9f2c0e87"
+WORKSPACE_ID = "95191203-a0b8-4fc0-8b20-4efe831708e9"
+SUBCAT_ID    = "acf1bb34-2055-411e-88be-d840efcc7424"
+
+
+def gir(line, sort, field, width, caption, row_id, default_nav=0):
+    return (f'            <GIResult LineNbr="{line}" SortOrder="{sort}" IsActive="1" '
+            f'Field="{field}" Width="{width}" IsVisible="1" DefaultNav="{default_nav}" '
+            f'QuickFilter="0" FastFilter="1" Caption="{caption}" RowID="{row_id}" />')
+
+
+def gitable(alias, name, inner_lines):
+    inner = "\n".join(inner_lines) if inner_lines else ""
+    if inner:
+        return f'          <GITable Alias="{alias}" Name="{name}">\n{inner}\n          </GITable>'
+    return f'          <GITable Alias="{alias}" Name="{name}">\n          </GITable>'
+
+
+def girelation(line_nbr, child_table, ons, join="L"):
+    ons_xml = "\n".join(
+        f'              <GIOn LineNbr="{i+1}" ParentField="{p}" Condition="E " ChildField="{c}" Operation="A" />'
+        for i, (p, c) in enumerate(ons)
+    )
+    return (f'            <GIRelation LineNbr="{line_nbr}" ChildTable="{child_table}" IsActive="1" JoinType="{join}">\n'
+            f'{ons_xml}\n'
+            f'            </GIRelation>')
+
+
+# ===========================================================================
+# A.3 DRP_OpenPOLines — POLine × POOrder × UsrContainerPOLink × UsrContainer
+# ===========================================================================
+# Base: POLine (alias "Line")
+#   join L POOrder on (OrderType, OrderNbr)
+#   join L UsrContainerPOLink on (OrderType, OrderNbr, LineNbr)
+# UsrContainerPOLink
+#   join L UsrContainer on (ContainerID)
+#
+# POOrderExt.UsrAcknowledgedDate and UsrFactoryReadyDate are automatically
+# available as POOrder.UsrAcknowledgedDate / POOrder.UsrFactoryReadyDate
+# inside a GI once the DAC extension is deployed (per #311). No separate
+# <GITable> entry needed for POOrderExt.
+#
+# Filters:
+#   POLine.LineType = 'GoodsForInventory'
+#   POLine.OpenQty > 0
+#   POOrder.Status IN ('N','O')   -- Pending or Open
+#
+# Sort: POLine.PromisedDate ASC (soonest-due first — drives DRP urgency)
+
+line_relations = [
+    girelation(1, "POOrder", [
+        ("OrderType", "OrderType"),
+        ("OrderNbr",  "OrderNbr"),
+    ]),
+    girelation(2, "ContainerLink", [
+        ("OrderType", "OrderType"),
+        ("OrderNbr",  "OrderNbr"),
+        ("LineNbr",   "LineNbr"),
+    ]),
+]
+
+# Default nav on POOrderNbr so users can drill into the PO from the GI.
+line_results = [
+    gir(1, 1, "OrderType",     60, "PO Type",      A3_ROW["POType"]),
+    gir(2, 2, "OrderNbr",     100, "PO Nbr",       A3_ROW["POOrderNbr"], default_nav=1),
+    gir(3, 3, "LineNbr",       60, "Line Nbr",     A3_ROW["POLineNbr"]),
+    gir(4, 4, "InventoryID",  120, "Inventory ID", A3_ROW["InventoryID"]),
+    gir(5, 5, "VendorID",     100, "Vendor",       A3_ROW["VendorID"]),
+    gir(6, 6, "OrderQty",      80, "Order Qty",    A3_ROW["OrderQty"]),
+    gir(7, 7, "ReceivedQty",   80, "Received",     A3_ROW["ReceivedQty"]),
+    gir(8, 8, "OpenQty",       80, "Open Qty",     A3_ROW["OpenQty"]),
+    gir(9, 9, "PromisedDate", 100, "Promised Date", A3_ROW["PromisedDate"]),
+]
+
+order_results = [
+    gir(10, 10, "UsrAcknowledgedDate", 110, "Vendor Ack'd",   A3_ROW["UsrAcknowledgedDate"]),
+    gir(11, 11, "UsrFactoryReadyDate", 110, "Factory Ready",  A3_ROW["UsrFactoryReadyDate"]),
+]
+
+container_link_relations = [
+    girelation(3, "Container", [("ContainerID", "ContainerID")]),
+]
+
+container_results = [
+    gir(12, 12, "ContainerCD", 120, "Container Nbr", A3_ROW["ContainerNbr"]),
+]
+
+A3_GIDESIGN = f'''        <row DesignID="{A3_DESIGN}" Name="DRP_OpenPOLines" ScreenID="SB401100" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+{gitable("Line", "PX.Objects.PO.POLine", line_relations + line_results)}
+{gitable("POOrder", "PX.Objects.PO.POOrder", order_results)}
+{gitable("ContainerLink", "StudioB.Containers.UsrContainerPOLink", container_link_relations)}
+{gitable("Container", "StudioB.Containers.UsrContainer", container_results)}
+          <GIWhere LineNbr="1" IsActive="1" DataFieldName="Line.LineType" Condition="E " IsExpression="0" Value1="GoodsForInventory" Operation="A" />
+          <GIWhere LineNbr="2" IsActive="1" DataFieldName="Line.OpenQty" Condition="G " IsExpression="0" Value1="0" Operation="A" />
+          <GIWhere LineNbr="3" OpenBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="N" Operation="A" />
+          <GIWhere LineNbr="4" CloseBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="O" Operation="O" />
+          <GISort LineNbr="1" IsActive="1" DataFieldName="Line.PromisedDate" SortOrder="A" />
+          <SiteMap linkname="toDesignById">
+            <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id={A3_DESIGN}" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="{A3_NODE}" ParentID="{PARENT_ID}">
+              <MUIScreen IsPortal="0" WorkspaceID="{WORKSPACE_ID}" Order="2100" SubcategoryID="{SUBCAT_ID}" />
+            </row>
+          </SiteMap>
+
+        </row>'''
+
+
+def main():
+    text = PROJ.read_text()
+
+    if A3_DESIGN in text:
+        print(f"ERROR: A.3 DesignID {A3_DESIGN} already present — refusing to duplicate.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Extract relations+layout boilerplate from the first GI in the file.
+    rel_match = re.search(
+        r'(<GenericInquiryScreen>\s*<data-set>\s*<relations format-version="3".*?</layout>)',
+        text, flags=re.DOTALL)
+    if not rel_match:
+        print("ERROR: could not locate <relations>...</layout> boilerplate", file=sys.stderr)
+        sys.exit(1)
+    boilerplate_header = rel_match.group(1)
+
+    new_block = (
+        f'    {boilerplate_header}\n'
+        f'    <data>\n'
+        f'      <GIDesign>\n'
+        f'{A3_GIDESIGN}\n'
+        f'      </GIDesign>\n'
+        f'    </data>\n'
+        f'  </data-set>\n'
+        f'</GenericInquiryScreen>'
+    )
+
+    anchor = '    <ScreenWithRights AccessRightsMergeRule="ApplyAndKeep">'
+    if text.count(anchor) != 1:
+        print(f"ERROR: anchor not unique (count={text.count(anchor)})", file=sys.stderr)
+        sys.exit(1)
+
+    updated = text.replace(anchor, new_block + "\n" + anchor)
+
+    if "--dry-run" in sys.argv:
+        print(f"OK: would insert {len(new_block)} chars ({new_block.count(chr(10))+1} lines)")
+        print(f"    A.3 DesignID = {A3_DESIGN}")
+        return
+
+    PROJ.write_text(updated)
+    print(f"WROTE: {PROJ}")
+    print(f"  file grew from {len(text)} to {len(updated)} bytes ({len(updated)-len(text):+d})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/heritage/validate_publish_gi.py
+++ b/scripts/heritage/validate_publish_gi.py
@@ -14,6 +14,7 @@ PROBE_GIS = [
     # DRP Phase 0 Stream A (2026-04-09) — inline GIs in AesthetikContainers
     "DRP_VelocityHistory",     # SB401080 — SOShipLine × SOShipment × SOLine
     "DRP_OpenSOCommitments",   # SB401090 — SOLine × SOOrder
+    "DRP_OpenPOLines",         # SB401100 — POLine × POOrder × UsrContainerPOLink × UsrContainer
     "DRP_InventoryBySite",     # SB401110 — InventoryItem × INSiteStatus
 ]
 

--- a/tests/test_drp_phase0_gis.py
+++ b/tests/test_drp_phase0_gis.py
@@ -41,6 +41,13 @@ EXPECTED_GIS = {
         {"InventoryID", "OrderType", "OrderNbr", "LineNbr", "OrderQty", "ShippedQty",
          "OpenQty", "RequestedDate", "CustomerID", "SiteID", "UOM"},
     ),
+    "SB401100": (
+        "DRP_OpenPOLines",
+        "Line",
+        {"OrderType", "OrderNbr", "LineNbr", "InventoryID", "VendorID", "OrderQty",
+         "ReceivedQty", "OpenQty", "PromisedDate",
+         "UsrAcknowledgedDate", "UsrFactoryReadyDate", "ContainerCD"},
+    ),
     "SB401110": (
         "DRP_InventoryBySite",
         "InventoryItem",


### PR DESCRIPTION
## Summary

Ships the **4th and final** Stream A signal GI for DRP Phase 0. A.3 was blocked by B.1 (POOrder DAC fields), which landed in #311. With the new `UsrAcknowledgedDate` + `UsrFactoryReadyDate` fields now compiled into `StudioB.Containers.dll`, this GI can reference them inside its `<GIResult>` block.

**DRP_OpenPOLines** (SB401100) — `POLine × POOrder × UsrContainerPOLink × UsrContainer`

Exposes open-qty PO commitments to the DRP forecaster so it can compute expected inbound supply against forecasted demand. The `UsrAcknowledgedDate` + `UsrFactoryReadyDate` fields feed the 4-stage lead-time learner (design §4.5, §12).

## Cross-repo dependencies (rule #6)

| | Status |
|---|---|
| **UPSTREAM** — #311 POOrder DRP fields | ✅ Merged (commit `c03a48a`) — Acumatica deploy in progress |
| **UPSTREAM** — #312 Stream A A.1/A.2/A.4 | ✅ Merged (commit `07a54ef`) — Acumatica deploy in progress |
| **DOWNSTREAM** — P0-A.5 studiob-api gateway | ⏸️ Next session — now unblocked for all 4 Stream A GIs |
| **DOWNSTREAM** — P0-D.2 lead-time-learner | ⏸️ Next session — consumes UsrAcknowledged/UsrFactoryReady via this GI |

**Deploy ordering:** A.3 can only publish AFTER #311 has actually deployed to the live sandbox (not just merged) — the DLL with the new DAC fields must be on disk when A.3 tries to publish. The AcuOps deploy workflow's concurrency group serializes queued deploys, so this ordering is automatic as long as #311 and A.3 are merged in order. Safe to merge this PR now; the deploy will queue behind #311+#312.

## What changed

| File | Change |
|---|---|
| `Customization/AesthetikContainers/project.xml` | +183 lines: 1 new `<GenericInquiryScreen>` block before `<ScreenWithRights>` |
| `scripts/build_drp_a3_gi.py` | **NEW** — reproducible builder with idempotency guard |
| `scripts/heritage/validate_publish_gi.py` | +1 line: PROBE_GIS extended with `DRP_OpenPOLines` |
| `tests/test_drp_phase0_gis.py` | +7 lines: SB401100 metadata added to `EXPECTED_GIS` (covered automatically by the existing parametrized assertions) |

## Result columns (12)

| Alias | Field | Caption |
|---|---|---|
| Line | OrderType | PO Type |
| Line | OrderNbr | PO Nbr (default nav) |
| Line | LineNbr | Line Nbr |
| Line | InventoryID | Inventory ID |
| Line | VendorID | Vendor |
| Line | OrderQty | Order Qty |
| Line | ReceivedQty | Received |
| Line | OpenQty | Open Qty |
| Line | PromisedDate | Promised Date |
| POOrder | **UsrAcknowledgedDate** | Vendor Ack'd |
| POOrder | **UsrFactoryReadyDate** | Factory Ready |
| Container | ContainerCD | Container Nbr |

## Filters

- `Line.LineType = 'GoodsForInventory'`
- `Line.OpenQty > 0`
- `POOrder.Status IN ('N','O')` (Pending or Open)

## Sort

`Line.PromisedDate ASC` — soonest-due first drives DRP urgency

## Validation ✅

- `python3 scripts/validate-project.py --strict Customization/AesthetikContainers/project.xml` → **PASSED with 1 warning** (baseline parity — same as pre-change main)
- `pytest tests/test_drp_phase0_gis.py -v` → **21/21 passing** (16 pre-existing for SB401080/90/110 + 5 new parametrized for SB401100)
- ElementTree round-trip parse verified

## Test plan

- [x] `validate-project.py --strict` passes (no new warnings)
- [x] `tests/test_drp_phase0_gis.py` 21/21 green
- [x] ElementTree parse + GIDesign row lookup verified
- [ ] CI Build + Acuminator green (self-hosted Windows runner)
- [ ] Merge after #311 deploys successfully (verified by Playwright confirming `UsrAcknowledgedDate` field visible on PO301000) — otherwise A.3 publish will fail with "field not found"
- [ ] Post-deploy: Playwright opens SB401100 in sandbox, confirms rows with all 12 expected columns including the two POOrderExt fields
- [ ] Post-deploy: `validate_publish_gi.py` probe picks up DRP_OpenPOLines

## Phase 0 scoreboard

Before this PR: 13/25 (Wave 1 + A.1/A.2/A.4 + B.1 + F.1.b + F.1.c backend)
After this PR lands + deploys: **14/25** (+ A.3, Stream A complete)

Refs: `docs/plans/2026-04-10-drp-phase-0-implementation-plan.md` §P0-A.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)