### PR TITLE
feat(larry): Gate 2 close + error signatures + Gate 3 dispatch counter

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -1949,10 +1949,10 @@ jobs:
   # ACUMATICA_SANDBOX_URL/TENANT secrets pointed at prod / Heritage Test,
   # every retry recycled the prod app pool. 8 prod restarts in 14 hours.
   # Re-enable only after:
-  #   1. ACUMATICA_SANDBOX_URL + ACUMATICA_SANDBOX_TENANT corrected
+  #   1. ✅ ACUMATICA_SANDBOX_URL + ACUMATICA_SANDBOX_TENANT corrected (2026-04-07)
   #   2. ✅ GH_PAT_DISPATCH retired — acuops-agent App token live (Task 2.3, 2026-04-09)
-  #   3. Recovery agent capped at N total dispatches per 24h via an
-  #      external counter the agent itself cannot reset
+  #   3. ✅ Recovery agent capped at 5 dispatches per 24h via LARRY_DISPATCH_COUNT
+  #      GH variable + LARRY_KILL_SWITCH external off switch (2026-04-09)
   invoke-agent:
     name: AI Failure Recovery (DISABLED)
     needs: [build, qualify, sandbox-gate]
@@ -1986,7 +1986,79 @@ jobs:
           # (Safety Package gate #2: agent attribution must not be Kevin).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # ── Larry Loop safety gates (contract: larry-loop.md) ────────────
+      - name: Check Larry kill switch
+        id: larry-kill
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          KILL=$(gh variable get LARRY_KILL_SWITCH --repo ${{ github.repository }} 2>/dev/null || echo "false")
+          if [ "$KILL" = "true" ]; then
+            echo "::warning::Larry kill switch is ON — skipping AI recovery"
+            echo "killed=true" >> $GITHUB_OUTPUT
+          else
+            echo "killed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check Larry dispatch counter
+        id: larry-counter
+        if: steps.larry-kill.outputs.killed != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNTER_JSON=$(gh variable get LARRY_DISPATCH_COUNT --repo ${{ github.repository }} 2>/dev/null || echo '{"count":0,"window_start":"1970-01-01T00:00:00Z"}')
+          COUNT=$(echo "$COUNTER_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['count'])")
+          WINDOW=$(echo "$COUNTER_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['window_start'])")
+
+          # Reset window if expired (>24h)
+          EXPIRED=$(python3 -c "
+          from datetime import datetime, timezone, timedelta
+          window = datetime.fromisoformat('$WINDOW'.replace('Z','+00:00'))
+          now = datetime.now(timezone.utc)
+          print('true' if (now - window) > timedelta(hours=24) else 'false')
+          ")
+
+          if [ "$EXPIRED" = "true" ]; then
+            COUNT=0
+            WINDOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          fi
+
+          CAP=5
+          if [ "$COUNT" -ge "$CAP" ]; then
+            echo "::error::Larry dispatch counter at $COUNT/$CAP (window started $WINDOW). Budget exhausted — escalating."
+            echo "blocked=true" >> $GITHUB_OUTPUT
+          else
+            echo "Larry dispatch counter: $COUNT/$CAP (window started $WINDOW)"
+            echo "blocked=false" >> $GITHUB_OUTPUT
+            echo "new_count=$((COUNT + 1))" >> $GITHUB_OUTPUT
+            echo "window_start=$WINDOW" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Increment Larry dispatch counter
+        if: steps.larry-kill.outputs.killed != 'true' && steps.larry-counter.outputs.blocked != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh variable set LARRY_DISPATCH_COUNT \
+            --repo ${{ github.repository }} \
+            --body "{\"count\":${{ steps.larry-counter.outputs.new_count }},\"window_start\":\"${{ steps.larry-counter.outputs.window_start }}\"}"
+
+      - name: Escalate on budget exhaustion
+        if: steps.larry-counter.outputs.blocked == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          # DM Kevin (fallback originator) with Larry escalation payload
+          curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"channel\": \"U0ALNRQ4KF0\",
+              \"text\": \"⚠️ *Larry dispatch budget exhausted* — AI Failure Recovery hit 5/5 dispatches in 24h.\nProject: ${{ needs.build.outputs.project_name }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>\n\nManual triage required. Reset counter: \`gh variable set LARRY_DISPATCH_COUNT --repo ${{ github.repository }} --body '{\\\"count\\\":0,\\\"window_start\\\":\\\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\\\"}'\`\"
+            }" > /dev/null
+
       - name: Run failure recovery agent
+        if: steps.larry-kill.outputs.killed != 'true' && steps.larry-counter.outputs.blocked != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -1930,8 +1930,7 @@ jobs:
   # every retry recycled the prod app pool. 8 prod restarts in 14 hours.
   # Re-enable only after:
   #   1. ACUMATICA_SANDBOX_URL + ACUMATICA_SANDBOX_TENANT corrected
-  #   2. GH_PAT_DISPATCH replaced with a service-account PAT (so audit
-  #      log shows the agent, not Kevin)
+  #   2. ✅ GH_PAT_DISPATCH retired — acuops-agent App token live (Task 2.3, 2026-04-09)
   #   3. Recovery agent capped at N total dispatches per 24h via an
   #      external counter the agent itself cannot reset
   invoke-agent:

--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -1689,6 +1689,7 @@ jobs:
           ACUDEV_API_KEY: ${{ secrets.ACUDEV_API_KEY }}
         run: |
           ERROR_DETAIL="Verification failed"
+          ERROR_SIGNATURE="verify:unknown"
           if [ -f verify-result.json ]; then
             ERROR_DETAIL=$(python3 -c "
           import sys, json
@@ -1696,6 +1697,24 @@ jobs:
           fails = [c for c in d.get('checks', []) if c['status'] == 'fail']
           print('; '.join(f\"{c['name']}: {c['detail']}\" for c in fails[:5]))
           " 2>/dev/null || echo "Verification failed — see logs")
+            # Derive canonical error signature (see docs/architecture/error-signatures.md)
+            ERROR_SIGNATURE=$(python3 -c "
+          import json
+          d = json.load(open('verify-result.json'))
+          fails = [c for c in d.get('checks', []) if c['status'] == 'fail']
+          if not fails: print('verify:unknown')
+          else:
+              c = fails[0]
+              name = c['name'].lower().replace(' ', '-')
+              detail = c.get('detail', '')
+              suffix = ''
+              if '401' in detail: suffix = '-401'
+              elif '404' in detail: suffix = '-404'
+              elif '500' in detail: suffix = '-500'
+              elif 'timeout' in detail.lower(): suffix = '-timeout'
+              elif 'mismatch' in detail.lower(): suffix = '-mismatch'
+              print(f'verify:{name}{suffix}')
+          " 2>/dev/null || echo "verify:unknown")
           fi
           curl -sf -X POST "${ACUDEV_URL}/ingest/incident" \
             -H "Content-Type: application/json" \
@@ -1706,6 +1725,7 @@ jobs:
               \"environment\": \"${{ steps.env.outputs.target }}\",
               \"commit\": \"${GITHUB_SHA::8}\",
               \"error_detail\": $(echo "$ERROR_DETAIL" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))'),
+              \"error_signature\": \"${ERROR_SIGNATURE}\",
               \"run_url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
               \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
             }" || echo "[WARN] Auto-ingestion failed — non-blocking"

--- a/docs/architecture/error-signatures.md
+++ b/docs/architecture/error-signatures.md
@@ -1,0 +1,167 @@
+# Error Signature Canonicalization — Pipeline Reference
+
+> **Status:** v1 — acuops-deploy surface only
+> **Owner:** Studio B AI
+> **Created:** 2026-04-09
+> **Related:** `~/dev/studiob/docs/architecture/larry-loop.md` (open question #1)
+
+## Purpose
+
+Every deploy incident ingested into `studiob-knowledge` gets a canonical `error_signature` string. Larry Loop uses this as the primary KB search key in its KB-first step (invariant #1). Signatures must be:
+
+1. **Stable** — same root cause produces the same signature across runs
+2. **Searchable** — exact-match filtering before semantic fallback
+3. **Human-readable** — operators can scan them without decoding
+
+## Format
+
+```
+{surface}:{check}-{detail}
+```
+
+- `surface` — pipeline stage that produced the error
+- `check` — specific check or operation that failed
+- `detail` — HTTP status code, error class, or qualifier
+
+All lowercase, colon-separated, no spaces. Hyphens within segments only.
+
+## Signature Catalog — acuops-deploy surface
+
+### verify (post-publish verification via verify.py)
+
+verify.py produces `verify-result.json` with checks array. Each check has `name`, `status`, `detail`.
+
+| Signature | Trigger | Resolution hint |
+|-----------|---------|-----------------|
+| `verify:login-401` | Login returns 401 | Check ACUMATICA_PROD_USERNAME/PASSWORD secrets |
+| `verify:login-500` | Login returns 500 | API Login Limit — wait for session slots to free |
+| `verify:entity:{name}-401` | Entity GET returns 401 after successful login | Session cookie bug in verify.py (known: P1.3) |
+| `verify:entity:{name}-404` | Entity GET returns 404 | Custom entity not deployed or API not enabled |
+| `verify:entity:{name}-500` | Entity GET returns 500 | App pool unstable post-publish |
+| `verify:field:{entity}.{field}-404` | Custom field not found in $adHocSchema | Field not in DAC extension or publish didn't include project |
+| `verify:gi:health-500` | GI subsystem returns 500+ | GI corruption post-publish — check System Monitor |
+| `verify:aspx:{screen}-mismatch` | ASPX file on instance doesn't match deployed package | `--no-merge` skipped ASPX extraction (known: PR #150 pattern) |
+| `verify:unknown` | No checks failed but overall status is fail | Unexpected verify.py output — inspect logs |
+
+### deploy (publish via deploy.sh / deploy.py)
+
+| Signature | Trigger | Resolution hint |
+|-----------|---------|-----------------|
+| `deploy:login-401` | Login returns 401 | Bad credentials |
+| `deploy:login-limit-500` | Login returns 500 (retried 5x) | API Login Limit — all session slots consumed |
+| `deploy:api-unavailable-404` | Customization API returns 404/405 | API not enabled on instance |
+| `deploy:preflight-400` | Pre-flight validation returns 400 | XML/compile error in project — check pre-flight logs |
+| `deploy:preflight-500` | Pre-flight returns 500 | Server error — check System Monitor, retry |
+| `deploy:import-500` | Package import returns 500 | Import failed — publish may be in progress |
+| `deploy:publish-begin-500` | publishBegin returns 500 | Publish in progress or app pool issue |
+| `deploy:publish-500` | Publish fails after begin | Compilation/SQL error during publish |
+| `deploy:publish-timeout` | Publish exceeds POLL_TIMEOUT (600s default) | Increase timeout or check System Monitor |
+| `deploy:smoke-500` | Post-publish smoke test returns 500 | App pool didn't restart cleanly |
+| `deploy:db-corruption-nre` | NullReferenceException during publish | **NEVER RETRY** — file Acumatica support ticket |
+| `deploy:unpublish-audit-{projects}` | Pre-publish audit detects projects that would be unpublished | Review co-publish manifest |
+| `deploy:target-mismatch` | PROD_URL/TENANT don't match expected values | Check secrets — safety assertion failed |
+
+### build (dotnet build + Acuminator on Windows)
+
+| Signature | Trigger | Resolution hint |
+|-----------|---------|-----------------|
+| `build:compile-{CSxxxx}` | C# compiler error | Fix source code — error code in detail |
+| `build:dll-missing-{project}` | DLL not produced after build | Check .csproj, dotnet restore |
+| `build:sdk-missing` | SDK DLLs not found (local or GCS) | Check GCS bucket or local lib/ |
+| `build:acuminator-{PXxxxx}` | Acuminator diagnostic (advisory, non-blocking) | Style issue — fix when convenient |
+
+### sandbox (sandbox-gate job)
+
+| Signature | Trigger | Resolution hint |
+|-----------|---------|-----------------|
+| `sandbox:host-mismatch` | SANDBOX_URL doesn't point to sandbox instance | Check ACUMATICA_SANDBOX_URL secret |
+| `sandbox:tenant-prod` | SANDBOX_TENANT = "Heritage Test" (prod instance tenant) | Check ACUMATICA_SANDBOX_TENANT secret |
+| `sandbox:publish-500` | Sandbox publish returns 500 | App pool issue on sandbox |
+| `sandbox:publish-timeout` | Sandbox publish exceeds timeout | Check sandbox System Monitor |
+| `sandbox:smoke-500` | Post-publish smoke test on sandbox returns 500 | Sandbox app pool unstable |
+| `sandbox:odata-404-fixtures` | OData 404 during UI fixture generation | Workflow extractor failure (P1.1) |
+| `sandbox:ui-tests-fail` | Playwright UI tests fail on sandbox | Business logic regression |
+
+## Special signatures
+
+### NEVER-RETRY list
+
+These signatures cause Larry Loop to escalate immediately without retrying:
+
+- `deploy:db-corruption-nre` — database corruption requires human investigation
+- `sandbox:host-mismatch` — misconfigured secrets, agent can't fix
+- `sandbox:tenant-prod` — misconfigured secrets, agent can't fix
+- `deploy:target-mismatch` — misconfigured secrets, agent can't fix
+
+### Compound signatures
+
+When multiple checks fail, use the **first failure** as the primary signature. Store the full list in `error_detail` for context.
+
+## Derivation logic
+
+### From verify-result.json
+
+```python
+import json
+
+def derive_verify_signature(result_path: str) -> str:
+    d = json.load(open(result_path))
+    fails = [c for c in d.get('checks', []) if c['status'] == 'fail']
+    if not fails:
+        return 'verify:unknown'
+    c = fails[0]
+    name = c['name'].lower().replace(' ', '-')
+    detail = c.get('detail', '')
+    suffix = ''
+    if '401' in detail: suffix = '-401'
+    elif '404' in detail: suffix = '-404'
+    elif '500' in detail: suffix = '-500'
+    elif 'timeout' in detail.lower(): suffix = '-timeout'
+    elif 'mismatch' in detail.lower(): suffix = '-mismatch'
+    return f'verify:{name}{suffix}'
+```
+
+### From deploy.sh exit
+
+deploy.sh writes structured output to stdout. The calling workflow captures the exit code and last error line. Derivation:
+
+```bash
+# In acuops-deploy.yml after deploy step failure:
+if grep -q "NullReferenceException" deploy-output.log; then
+  ERROR_SIGNATURE="deploy:db-corruption-nre"
+elif grep -q "API Login Limit" deploy-output.log; then
+  ERROR_SIGNATURE="deploy:login-limit-500"
+elif grep -q "pre-flight.*400" deploy-output.log; then
+  ERROR_SIGNATURE="deploy:preflight-400"
+# ... etc
+fi
+```
+
+## Qdrant metadata schema
+
+New incidents include `error_signature` in the chunk metadata:
+
+```json
+{
+  "domain": "pipeline",
+  "client": "aesthetik",
+  "source_type": "incident",
+  "event": "verification_failed",
+  "error_signature": "verify:entity:SOOrder-401",
+  "project": "AesthetikWMS",
+  "environment": "production",
+  "commit": "abc123ef",
+  "timestamp": "2026-04-09T22:30:00Z"
+}
+```
+
+Larry Loop's KB-first query filters on `error_signature` (exact match) before falling back to semantic search on the `text` field.
+
+## Future surfaces
+
+When new surfaces implement Larry (portal, DRP, WMS), add their signature catalogs here following the same format. The `{surface}:{check}-{detail}` pattern extends naturally:
+
+- `portal:planner-timeout` — Opus planner exceeded budget
+- `portal:executor-branch-routing` — Wrong repo routed
+- `drp:signal-parse-fail` — DRP signal email couldn't be parsed
+- `wms:sentry-{fingerprint}` — Runtime error from Sentry webhook

--- a/scripts/post-publish-hook.ts
+++ b/scripts/post-publish-hook.ts
@@ -4,7 +4,7 @@
  * INSTALLATION (in studio-b-ai/acumatica-ci-cd):
  *
  * 1. Copy dispatch-test-config.ts to scripts/dispatch-test-config.ts
- * 2. Add GH_PAT_DISPATCH to GitHub Actions secrets
+ * 2. Add ACUOPS_AGENT_APP_ID + ACUOPS_AGENT_PRIVATE_KEY to GitHub Actions secrets
  * 3. Add a post-publish step to the deploy workflow (see below)
  *
  * This script parses the customization project XML to find new DAC extension


### PR DESCRIPTION
## Summary
- **Gate 2:** Update remaining `GH_PAT_DISPATCH` comment refs (active code already migrated in PR #290)
- **Error signatures:** Add `docs/architecture/error-signatures.md` canonicalization spec + derive `error_signature` in auto-ingest step
- **Gate 3:** Larry dispatch counter (5/24h cap) + kill switch via GH variables in invoke-agent job

All three Phase 4 Safety Package gates now have ✅ in the invoke-agent comment block. The job remains disabled (`if: false &&`) until dry-run validation.

## Cross-repo PRs (same effort)
- studio-b-ai/acudev#18 — shared `getAcuopsAgentToken()` lib + index.ts PAT fallback
- studio-b-ai/acuops#2 — deploy-asthetik.yml + dispatch scripts
- studio-b-ai/studiob-acumatica-ci-cd-template#2 — template dispatch scripts

## Test plan
- [ ] Merge cross-repo PRs, verify one deploy per repo uses acuops-agent[bot]
- [ ] Trigger a deploy with verify failure, confirm `error_signature` appears in Qdrant
- [ ] Set `LARRY_DISPATCH_COUNT` to `{"count":4,...}`, trigger invoke-agent, confirm it runs then blocks on 5th
- [ ] Set `LARRY_KILL_SWITCH=true`, confirm invoke-agent skips
- [ ] After all verified: delete `GH_PAT_DISPATCH` org-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)