### PR TITLE
feat(larry): enable invoke-agent dry-run [dry-run]

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -1954,11 +1954,10 @@ jobs:
   #   3. ✅ Recovery agent capped at 5 dispatches per 24h via LARRY_DISPATCH_COUNT
   #      GH variable + LARRY_KILL_SWITCH external off switch (2026-04-09)
   invoke-agent:
-    name: AI Failure Recovery (DISABLED)
+    name: AI Failure Recovery
     needs: [build, qualify, sandbox-gate]
     continue-on-error: true
     if: >-
-      false &&
       always() &&
       needs.build.result == 'success' &&
       needs.build.outputs.customization_changes == 'true' &&

--- a/publish-manifest.json
+++ b/publish-manifest.json
@@ -7,8 +7,8 @@
     },
     "SalesOrder": {
       "screen": "SO301000",
-      "custom_fields": [],
-      "_note": "UsrHubSpotDealId not exposed via $adHocSchema — validated via e2e_probes instead"
+      "custom_fields": ["custom.Document.UsrDryRunTest"],
+      "_note": "TEMP: UsrDryRunTest is intentionally non-existent — dry-run test for invoke-agent. Remove after dry-run succeeds."
     },
     "Customer": {
       "screen": "AR303000",


### PR DESCRIPTION
## Summary
- Removes `false &&` guard from invoke-agent job — all 3 Safety Package gates are ✅
- Injects bogus `UsrDryRunTest` field in publish-manifest.json to trigger a sandbox verify failure
- The recovery agent should fire, diagnose the missing field, and create a fix PR

## Dry-run procedure
1. **Before merging:** Set `LARRY_KILL_SWITCH=true` to validate the gate fires but agent is blocked
2. **After first run validates kill switch:** Set `LARRY_KILL_SWITCH=false`, reset counter, re-trigger
3. **Observe:** Agent diagnosis, fix PR creation, Slack DM, counter increment, Qdrant ingestion
4. **Clean up:** Merge the agent's fix PR (or manually revert UsrDryRunTest)

## Risk
Sandbox only — sandbox-gate failure blocks production deploy. Agent runs on ubuntu-latest, can only create PRs. Kill switch reachable at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)