### PR TITLE
fix(sandbox-gate): hard gate on verify.py failures [dry-run]

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -1007,6 +1007,32 @@ jobs:
           path: verify-result.json
           if-no-files-found: ignore
 
+      - name: Gate on verification failures
+        if: always() && steps.verify.outcome != 'skipped'
+        run: |
+          if [ ! -f verify-result.json ]; then
+            echo "::warning::verify-result.json not found — skipping gate"
+            exit 0
+          fi
+          FAIL_COUNT=$(python3 -c "
+          import json
+          d = json.load(open('verify-result.json'))
+          fails = [c for c in d.get('checks', []) if c['status'] == 'fail']
+          print(len(fails))
+          " 2>/dev/null || echo "0")
+          if [ "$FAIL_COUNT" -gt 0 ]; then
+            echo "::error::Verification found $FAIL_COUNT failing checks — blocking sandbox gate"
+            python3 -c "
+          import json
+          d = json.load(open('verify-result.json'))
+          for c in d.get('checks', []):
+              if c['status'] == 'fail':
+                  print(f\"  FAIL: {c['name']}: {c['detail']}\")
+          " 2>/dev/null || true
+            exit 1
+          fi
+          echo "All verification checks passed"
+
       - name: Post-publish smoke test
         id: smoke
         env:


### PR DESCRIPTION
## Summary
Adds a hard gate step after verify.py in sandbox-gate. Previously verify ran with `continue-on-error: true` and failures were informational — a missing custom field wouldn't block production deploy.

Now: verify failures fail the sandbox-gate job, which:
1. Blocks the production deploy job
2. Triggers the `invoke-agent` AI Failure Recovery job

The bogus `UsrDryRunTest` field from PR #317 is still in publish-manifest.json. Once this merges, sandbox-gate will fail on verify → invoke-agent fires (kill switch is currently ON).

## Test plan
1. Kill switch is ON — merge this, confirm sandbox-gate fails and invoke-agent is blocked by kill switch
2. Flip kill switch OFF, re-trigger — observe full agent run

🤖 Generated with [Claude Code](https://claude.com/claude-code)