### PR TITLE
fix(larry): enable show_full_output for agent diagnostics

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -2100,6 +2100,7 @@ jobs:
           # git. Without this, claude-code-action denies most tool calls (the
           # first dry-run hit 123 permission denials).
           # --max-turns caps reasoning iterations (replaces deprecated input).
+          show_full_output: true
           claude_args: |
             --allowedTools "Bash,Edit,Read,Write,Glob,Grep"
             --max-turns 30


### PR DESCRIPTION
## Summary
Previous agent run (24226285263) showed 0 permission denials and success, but no Slack DM or fix PR was created. Need `show_full_output: true` to see what the agent actually did.

## Test plan
- [ ] Merge → re-trigger → read full agent output in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)