### PR TITLE
chore: disable show_full_output + add VM auto-start workflow

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -2102,7 +2102,7 @@ jobs:
           # git. Without this, claude-code-action denies most tool calls (the
           # first dry-run hit 123 permission denials).
           # --max-turns caps reasoning iterations (replaces deprecated input).
-          show_full_output: true
+          show_full_output: false
           claude_args: |
             --allowedTools "Bash,Edit,Read,Write,Glob,Grep"
             --max-turns 50

--- a/.github/workflows/vm-autostart.yml
+++ b/.github/workflows/vm-autostart.yml
@@ -1,0 +1,54 @@
+# VM Auto-Start — ensure acumatica-test is running before business hours
+#
+# The acumatica-test GCE VM goes offline (auto-shutdown or preemption)
+# and blocks the build-validate job which runs on self-hosted Windows.
+# This workflow starts it at 8:00 AM ET (12:00 UTC) on weekdays.
+
+name: VM Auto-Start
+
+on:
+  schedule:
+    # 12:00 UTC = 8:00 AM ET (EDT), 7:00 AM ET (EST)
+    # Weekdays only
+    - cron: '0 12 * * 1-5'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write   # Required for Workload Identity Federation
+
+jobs:
+  start-vm:
+    name: Start acumatica-test VM
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Start VM if stopped
+        run: |
+          STATUS=$(gcloud compute instances describe acumatica-test \
+            --zone=us-central1-a \
+            --format='get(status)' 2>/dev/null || echo "UNKNOWN")
+
+          echo "Current VM status: $STATUS"
+
+          if [ "$STATUS" = "TERMINATED" ] || [ "$STATUS" = "STOPPED" ]; then
+            echo "Starting acumatica-test..."
+            gcloud compute instances start acumatica-test --zone=us-central1-a
+            echo "VM start command issued. Waiting for RUNNING state..."
+            gcloud compute instances tail-serial-port-output acumatica-test \
+              --zone=us-central1-a --timeout=60 2>/dev/null || true
+            echo "::notice::acumatica-test VM started successfully"
+          elif [ "$STATUS" = "RUNNING" ]; then
+            echo "::notice::acumatica-test is already running"
+          else
+            echo "::warning::acumatica-test is in unexpected state: $STATUS"
+          fi


### PR DESCRIPTION
## Summary
- **show_full_output → false** on invoke-agent (AI Failure Recovery). Agent is proven working, reduce log exposure.
- **New `vm-autostart.yml`** workflow: starts `acumatica-test` GCE VM at 8 AM ET weekdays. Uses existing GCP Workload Identity Federation. Prevents `build-validate` job failures from offline self-hosted runner.

## Cross-repo
- **acuops-pipeline PR #18**: fixes qualify health check StockItem 500 (same `$select` root cause as PR #337)

## Caveat
- GCP service account may need `compute.instances.start` permission for the VM auto-start workflow. Will verify on first run.

## Manual action needed
- Add `im:write` scope to Studio B Admin Slack bot at api.slack.com → OAuth & Permissions → Bot Token Scopes, then reinstall app

## Test plan
- [ ] Next pipeline run: verify invoke-agent step doesn't dump full output
- [ ] Trigger vm-autostart manually via workflow_dispatch to verify GCP auth + permissions
- [ ] Merge acuops-pipeline PR #18, then verify qualify step passes without force_qualify

🤖 Generated with [Claude Code](https://claude.com/claude-code)