### PR TITLE
fix: sandbox reliability — PO3010PL fix, --no-merge suppression, sandbox entity sync

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -1085,7 +1085,7 @@ jobs:
           fi
 
       - name: Run container tracking tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           ACUMATICA_URL: ${{ secrets.ACUMATICA_SANDBOX_URL }}
           ACUMATICA_USERNAME: ${{ secrets.ACUMATICA_SANDBOX_USERNAME }}

--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -997,6 +997,7 @@ jobs:
           python scripts/verify.py \
             --manifest publish-manifest.json \
             --environment sandbox \
+            --no-merge-expected acuops.yaml \
             --json-output verify-result.json
 
       - name: Upload verification result
@@ -1658,6 +1659,7 @@ jobs:
             --environment ${{ steps.env.outputs.target }} \
             --package "${{ needs.build.outputs.package_path }}" \
             --project "${{ needs.build.outputs.project_name }}" \
+            --no-merge-expected acuops.yaml \
             --json-output verify-result.json
 
       - name: Upload verification result
@@ -2295,6 +2297,7 @@ jobs:
             --environment staging \
             --package "${{ needs.build.outputs.package_path }}" \
             --project "${{ needs.build.outputs.project_name }}" \
+            --no-merge-expected acuops.yaml \
             --json-output verify-result.json \
             2>&1 | tee validation-output.txt
 
@@ -2382,6 +2385,7 @@ jobs:
           python scripts/verify.py \
             --manifest publish-manifest.json \
             --environment production \
+            --no-merge-expected acuops.yaml \
             --json-output verify-result.json
 
       - name: Publish test metrics

--- a/.github/workflows/sync-sandbox.yml
+++ b/.github/workflows/sync-sandbox.yml
@@ -1,0 +1,43 @@
+name: Sync Sandbox Data
+
+on:
+  schedule:
+    - cron: "23 8 * * *"  # 3:23am ET (after prod→test sync at 2:07am)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (read only, no writes)"
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    name: Entity Sync — Prod → Sandbox
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests pyyaml
+
+      - name: Run entity sync to sandbox
+        env:
+          PYTHONUNBUFFERED: "1"
+          ACUMATICA_URL: ${{ secrets.ACUMATICA_PROD_URL }}
+          ACUMATICA_USERNAME: ${{ secrets.ACUMATICA_PROD_USERNAME }}
+          ACUMATICA_PASSWORD: ${{ secrets.ACUMATICA_PROD_PASSWORD }}
+          PROD_TENANT: "Heritage Fabrics"
+          SANDBOX_URL: ${{ secrets.ACUMATICA_SANDBOX_URL }}
+          SANDBOX_USERNAME: ${{ secrets.ACUMATICA_SANDBOX_USERNAME }}
+          SANDBOX_PASSWORD: ${{ secrets.ACUMATICA_SANDBOX_PASSWORD }}
+          SANDBOX_TENANT: ${{ secrets.ACUMATICA_SANDBOX_TENANT }}
+          SLACK_WEBHOOK_URL: ${{ secrets.STUDIOB_SLACK_WEBHOOK_URL }}
+        run: python scripts/heritage/entity-sync.py --target sandbox

--- a/Customization/AesthetikWMS/project.xml
+++ b/Customization/AesthetikWMS/project.xml
@@ -414,7 +414,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('INItemXRef
             </layout>
             <data>
                 <SiteMap>
-                    <row Position="0" Title="Purchase Orders" Url="~/Pages/PO/PO301000.aspx" ScreenID="PO3010PL" NodeID="5FC65FCB-7860-40B1-A897-8526F240D9E0" ParentID="12167736-AE7E-46AB-8A8C-DD4B86217519" SelectedUI="E">
+                    <row Position="0" Title="Purchase Orders" Url="~/Pages/PO/PO301000.aspx" ScreenID="PO301000" NodeID="5FC65FCB-7860-40B1-A897-8526F240D9E0" ParentID="12167736-AE7E-46AB-8A8C-DD4B86217519" SelectedUI="E">
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>

--- a/acuops.yaml
+++ b/acuops.yaml
@@ -72,6 +72,14 @@ pipeline:
     - "StudioBAcuOps"
   test_tenant_enabled: true
 
+# ─── --no-merge Expected Failures ──────────────────────────────────────────
+# ASPX mismatches caused by --no-merge (isMergeWithExistingPackages=false).
+# --no-merge only extracts ASPX for the primary project; co-published
+# projects' ASPX files are silently skipped. These are downgraded to WARN
+# in verify.py until the IIG orphan rows are cleaned (September 2026 DB access).
+no_merge_expected:
+  - "aspx:Pages/SB/SB501000.aspx"
+
 # ─── Qualification (Pre-Deploy Gates) ──────────────────────────────────────
 qualification:
   deploy_cooldown: 15

--- a/docs/plans/2026-04-11-sandbox-reliability-design.md
+++ b/docs/plans/2026-04-11-sandbox-reliability-design.md
@@ -1,0 +1,104 @@
+# Sandbox Reliability — Design Doc
+
+**Date:** 2026-04-11
+**Status:** Approved
+**Context:** Sandbox-gate has blocked every deploy since Session 4 (2026-04-10). Three root causes identified: PO3010PL SiteMap shadow, --no-merge permanent verify failures, and stale sandbox data.
+
+## Workstream 1: Fix PO3010PL SiteMap Shadow
+
+**Root cause:** AesthetikWMS registers a SiteMap entry with `ScreenID="PO3010PL"` pointing to `~/Pages/PO/PO301000.aspx`. This shadows the stock PO301000 registration, causing `/Main?ScreenId=PO301000` to redirect to home instead of loading the PO form. Added in commit `a1b86d4` to restore access after a corrupt publish — used a custom ScreenID instead of the stock one.
+
+**Fix:** Change `ScreenID="PO3010PL"` → `ScreenID="PO301000"` in `Customization/AesthetikWMS/project.xml`. The `RolesInGraph` entries are stock defaults, not custom overrides.
+
+**Cleanup after fix:**
+- Revert `skipif(sandbox)` on `test_container_tracking_navigates_to_sb501000` (PR #353)
+- Revert direct-ASPX pattern in `test_container_tracking_button_exists` — use `acumatica_screen("PO301000")` fixture
+- Remove direct-ASPX pattern in `test_container_tracking_navigates_to_sb501000`
+- Update docstrings referencing PO3010PL shadow workaround
+
+**Deploy:** Next pipeline run publishes to sandbox + prod. One app pool restart.
+
+## Workstream 2: --no-merge Verify Failure Suppression (Until September)
+
+**Root cause:** Orphaned IIG metadata in the Acumatica publish registry causes `merge=true` to crash. Workaround: `--no-merge` (`isMergeWithExistingPackages: false`), which skips ASPX extraction for co-published projects. This produces 3 permanent verify failures every pipeline run.
+
+**Timeline:** Acumatica quoted an SOW for cleanup. Heritage Fabrics gets DB access in September 2026. `--no-merge` stays until then.
+
+### Part A: Orphan Row Map for September Cleanup
+
+Create `/docs/reference/iig-orphan-cleanup.md` documenting:
+
+Orphaned projects:
+- `IIGCONTAINERMGMT[24.204.0004][R19]1`
+- `IIGHFContainerMods[24.204.0004][R04]`
+- `AesthetikContainerGIs`
+
+Tables to clean: `CustProject`, `CustProjectMeta`, `CustPublishedProject` (and related).
+
+Include ready-to-run SQL DELETE statements for when DB access is available.
+
+### Part B: verify.py --no-merge Awareness
+
+Add `--no-merge-expected` flag to `verify.py` that:
+1. Reads the list of known ASPX mismatch screens caused by `--no-merge`
+2. Downgrades matching ASPX mismatch errors from FAIL → WARN
+3. Still reports them in output (visibility preserved)
+4. Does not count them toward the failure total
+
+Source the expected failure list from `acuops.yaml` or a dedicated config section.
+
+### Part C: Access Rights Verification
+
+Verify that users Melanie, Steve, and Lauren have access to:
+- SB501000 (Container Maintenance)
+- Related container tracking screens
+
+Sarah's access to PO302000 should also be verified (deferred from Session 4).
+
+## Workstream 3: Sandbox Data Freshness via Entity Sync
+
+**Problem:** Sandbox has stale/empty data. CRUD tests skipped, GIs render empty grids.
+
+**Approach:** Extend `scripts/heritage/entity-sync.py` to target sandbox in addition to test tenant.
+
+### Entities
+
+Already synced (prod → test):
+- Customer (with MainContact)
+- StockItem (with Attributes)
+- Vendor
+- Employee
+
+Add for container/DRP coverage:
+- PurchaseOrder (headers)
+- SalesOrder (headers)
+- Shipment (for DRP_VelocityHistory GI)
+
+### Schedule
+
+- Nightly, after existing prod → test sync
+- Also available on-demand via `workflow_dispatch`
+- Separate from deploy pipeline — data freshness does not gate deploys
+
+### What This Enables
+
+- Remove `skip_on_sandbox` from CRUD tests
+- GI column xfail tests may start passing (rows to render)
+- Verify checks run against prod-like data
+
+### What This Does NOT Replace
+
+Customization publish in sandbox-gate still handles GI definitions, DACs, ASPX files. Entity sync only fills in business data.
+
+## Dependencies Between Workstreams
+
+- Workstream 1 (PO3010PL) is independent — can ship immediately
+- Workstream 2 (--no-merge) is independent — can ship in parallel
+- Workstream 3 (entity sync) benefits from Workstream 1 being complete (tests that currently use direct-ASPX workarounds get simplified first)
+
+## Not In Scope
+
+- PCC Acumatica redesign (SB501000/SB501100/SB501200)
+- Full tenant snapshot via Playwright (SM301000)
+- Phase 2 DRP implementation
+- Removing sandbox-gate from pipeline

--- a/docs/plans/2026-04-11-sandbox-reliability-plan.md
+++ b/docs/plans/2026-04-11-sandbox-reliability-plan.md
@@ -1,0 +1,527 @@
+# Sandbox Reliability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix all three sandbox-gate blockers — PO3010PL SiteMap shadow, --no-merge verify noise, and stale sandbox data — so the pipeline flows without force_deploy overrides.
+
+**Architecture:** Three independent workstreams executed in order. WS1 fixes the customization XML and reverts test workarounds. WS2 adds a `--no-merge-expected` flag to verify.py and documents the IIG orphan cleanup SQL. WS3 extends entity-sync.py to target the sandbox instance.
+
+**Tech Stack:** Python (verify.py, entity-sync.py), XML (project.xml), YAML (acuops.yaml, GH Actions workflows)
+
+**Design doc:** `docs/plans/2026-04-11-sandbox-reliability-design.md`
+
+---
+
+## Workstream 1: Fix PO3010PL SiteMap Shadow
+
+### Task 1.1: Change ScreenID in AesthetikWMS project.xml
+
+**Files:**
+- Modify: `Customization/AesthetikWMS/project.xml:417`
+
+**Step 1: Make the change**
+
+In `Customization/AesthetikWMS/project.xml`, line 417, change:
+```xml
+<row Position="0" Title="Purchase Orders" Url="~/Pages/PO/PO301000.aspx" ScreenID="PO3010PL" NodeID="5FC65FCB-7860-40B1-A897-8526F240D9E0" ParentID="12167736-AE7E-46AB-8A8C-DD4B86217519" SelectedUI="E">
+```
+to:
+```xml
+<row Position="0" Title="Purchase Orders" Url="~/Pages/PO/PO301000.aspx" ScreenID="PO301000" NodeID="5FC65FCB-7860-40B1-A897-8526F240D9E0" ParentID="12167736-AE7E-46AB-8A8C-DD4B86217519" SelectedUI="E">
+```
+
+**Step 2: Verify no other PO3010PL references exist**
+
+Run: `grep -r "PO3010PL" Customization/`
+Expected: No matches (the only occurrence was line 417).
+
+**Step 3: Commit**
+
+```bash
+git add Customization/AesthetikWMS/project.xml
+git commit -m "fix: change PO3010PL SiteMap shadow back to PO301000
+
+The custom ScreenID was added to restore access after a corrupt publish.
+It shadows stock PO301000, breaking SiteMap navigation. The RolesInGraph
+entries are stock defaults — no custom overrides lost."
+```
+
+### Task 1.2: Revert test workarounds for PO3010PL
+
+**Files:**
+- Modify: `tests/ui/test_container_tracking.py:145-197`
+
+**Step 1: Rewrite test_container_tracking_button_exists to use acumatica_screen fixture**
+
+Replace lines 145-170 with:
+```python
+    def test_container_tracking_button_exists(self, acumatica_screen):
+        """CONTAINER TRACKING toolbar button should be present on PO301000."""
+        screen = acumatica_screen("PO301000")
+        screen.page.wait_for_timeout(3_000)
+
+        btn = screen.page.locator("text=CONTAINER TRACKING")
+        assert btn.count() > 0, "CONTAINER TRACKING button not found on PO301000"
+```
+
+Note: Change fixture from `acumatica_page` to `acumatica_screen`. The `acumatica_screen("PO301000")` fixture handles login + SiteMap navigation. The 3s wait is still needed for toolbar render (PXAction buttons injected by JS after domcontentloaded).
+
+**Step 2: Rewrite test_container_tracking_navigates_to_sb501000 to use acumatica_screen fixture**
+
+Replace lines 172-197 (including the `@pytest.mark.skipif` added in PR #353) with:
+```python
+    def test_container_tracking_navigates_to_sb501000(self, acumatica_screen):
+        """Clicking CONTAINER TRACKING should navigate to SB501000 without error."""
+        screen = acumatica_screen("PO301000")
+        screen.page.wait_for_timeout(3_000)
+
+        btn = screen.page.locator("text=CONTAINER TRACKING").first
+        if btn.is_visible(timeout=3000):
+            btn.click()
+            screen.page.wait_for_load_state("domcontentloaded")
+            screen.page.wait_for_timeout(3000)
+
+        assert "ScreenId=ERROR" not in screen.page.url, \
+            f"CONTAINER TRACKING button caused error. URL: {screen.page.url}"
+```
+
+Note: Removes `skipif(sandbox)` decorator AND the direct-ASPX pattern. Both are no longer needed once PO3010PL → PO301000 fix is deployed.
+
+**Step 3: Update docstrings referencing PO3010PL**
+
+Search for remaining PO3010PL references in test files:
+```bash
+grep -n "PO3010PL" tests/ui/test_container_tracking.py
+```
+Remove or update any remaining docstring references to PO3010PL shadow workaround.
+
+**Step 4: Commit**
+
+```bash
+git add tests/ui/test_container_tracking.py
+git commit -m "fix(tests): revert PO3010PL direct-ASPX workarounds
+
+PO3010PL→PO301000 fix in project.xml means SiteMap navigation works
+again. Tests can use the standard acumatica_screen fixture instead of
+direct ASPX URLs. Removes skipif(sandbox) from navigation test."
+```
+
+### Task 1.3: Verify access rights for Melanie, Steve, Lauren, and Sarah
+
+**Files:**
+- Modify: `Customization/AesthetikWMS/project.xml` (if access rights need adding)
+
+**Step 1: Check current access rights in project.xml**
+
+Search for RolesInGraph entries related to container tracking screens:
+```bash
+grep -A2 "ScreenID=\"SB501000\|ScreenID=\"PO302000\|ScreenID=\"SB401" Customization/AesthetikWMS/project.xml Customization/AesthetikContainers/project.xml
+```
+
+Document which roles have access to:
+- SB501000 (Container Maintenance) — Melanie, Steve, Lauren need access
+- PO302000 — Sarah needs access
+
+**Step 2: Verify users have appropriate roles**
+
+Check the Roles section of each project.xml for the roles that grant access. If the `*` wildcard role has `Accessrights="4"` on these screens, all users already have access. If specific roles are needed, add `RolesInGraph` entries.
+
+**Step 3: Commit if changes needed**
+
+```bash
+git add Customization/*/project.xml
+git commit -m "fix: ensure Melanie/Steve/Lauren access to SB501000, Sarah to PO302000"
+```
+
+---
+
+## Workstream 2: --no-merge Verify Failure Suppression
+
+### Task 2.1: Add no_merge_expected config to acuops.yaml
+
+**Files:**
+- Modify: `acuops.yaml`
+
+**Step 1: Add the expected failures section**
+
+Add after the `pipeline:` section (after line 73):
+```yaml
+# ─── --no-merge Expected Failures ──────────────────────────────────────────
+# ASPX mismatches caused by --no-merge (isMergeWithExistingPackages=false).
+# --no-merge only extracts ASPX for the primary project; co-published
+# projects' ASPX files are silently skipped. These are downgraded to WARN
+# in verify.py until the IIG orphan rows are cleaned (September 2026 DB access).
+no_merge_expected:
+  - "aspx:Pages/SB/SB501000.aspx"
+```
+
+Note: The exact ASPX paths must match what verify.py reports in the `aspx:{normalized}` check name. Run a verify to capture the exact 3 failure names if the above isn't exhaustive.
+
+**Step 2: Verify the YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('acuops.yaml'))"`
+Expected: No errors.
+
+**Step 3: Commit**
+
+```bash
+git add acuops.yaml
+git commit -m "chore: add no_merge_expected ASPX failure list to acuops.yaml
+
+Known ASPX mismatches from --no-merge mode. Will be removed when IIG
+orphan rows are cleaned after DB access in September 2026."
+```
+
+### Task 2.2: Add --no-merge-expected flag to verify.py
+
+**Files:**
+- Modify: `scripts/verify.py:636-689` (argparser), `scripts/verify.py:535-540` (ASPX check result)
+
+**Step 1: Add CLI argument**
+
+After line 688 (`args = parser.parse_args()` — but before it), add:
+```python
+    parser.add_argument(
+        "--no-merge-expected",
+        default=None,
+        help="Path to YAML file with no_merge_expected list of ASPX check names to downgrade FAIL→WARN",
+    )
+```
+
+**Step 2: Load expected failures in main()**
+
+After `args = parser.parse_args()` (line 689), add:
+```python
+    # Load --no-merge expected ASPX failures
+    no_merge_expected = set()
+    if args.no_merge_expected:
+        import yaml
+        with open(args.no_merge_expected) as f:
+            config = yaml.safe_load(f)
+        no_merge_expected = set(config.get("no_merge_expected", []))
+```
+
+**Step 3: Downgrade matching ASPX failures**
+
+Find the section where `all_checks` is assembled (around line 740-755). After all checks are collected but before the overall status is computed, add:
+```python
+    # Downgrade known --no-merge ASPX failures to WARN
+    if no_merge_expected:
+        for check in all_checks:
+            if (check.status == CheckStatus.FAIL
+                    and check.name in no_merge_expected
+                    and "not overwritten by import" in check.detail):
+                check.status = CheckStatus.WARN
+                check.detail += " [expected: --no-merge]"
+```
+
+**Step 4: Verify with a dry run**
+
+Run verify.py locally with the flag to confirm the expected failures downgrade:
+```bash
+python scripts/verify.py --manifest publish-manifest.json --environment sandbox \
+  --no-merge-expected acuops.yaml --json-output /tmp/verify-test.json 2>&1 | head -20
+```
+Expected: ASPX checks matching the list show `WARN` instead of `FAIL`.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/verify.py
+git commit -m "feat(verify): --no-merge-expected flag downgrades known ASPX failures to WARN
+
+Reads no_merge_expected list from acuops.yaml. Matching ASPX mismatch
+checks are downgraded FAIL→WARN so they don't block the gate while
+still reporting for visibility. Temporary until IIG orphan cleanup."
+```
+
+### Task 2.3: Wire --no-merge-expected into sandbox-gate workflow
+
+**Files:**
+- Modify: `.github/workflows/acuops-deploy.yml:997-1000`
+
+**Step 1: Update verify invocation in sandbox-gate**
+
+Find the sandbox verify step (around line 997). Change:
+```bash
+python scripts/verify.py \
+  --manifest publish-manifest.json \
+  --environment sandbox \
+  --json-output verify-result.json
+```
+to:
+```bash
+python scripts/verify.py \
+  --manifest publish-manifest.json \
+  --environment sandbox \
+  --no-merge-expected acuops.yaml \
+  --json-output verify-result.json
+```
+
+**Step 2: Also update production verify step**
+
+Find the production verify step (around line 1656). Add `--no-merge-expected acuops.yaml` to the command there too.
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/acuops-deploy.yml
+git commit -m "fix(pipeline): pass --no-merge-expected to verify.py in sandbox + prod
+
+Downgrades known ASPX mismatches from --no-merge mode so they don't
+block the sandbox gate or trigger false prod alerts."
+```
+
+### Task 2.4: Document IIG orphan cleanup SQL for September
+
+**Files:**
+- Create: `docs/reference/iig-orphan-cleanup.md`
+
+**Step 1: Write the cleanup reference doc**
+
+```markdown
+# IIG Orphan Row Cleanup — September 2026
+
+## Context
+
+Three ISV/internal packages were removed from Heritage Fabrics production
+but left orphaned metadata in the Acumatica publish registry. This forces
+`--no-merge` mode (`isMergeWithExistingPackages=false`) for all publishes,
+which skips ASPX extraction for co-published projects.
+
+Acumatica quoted an SOW for cleanup. Heritage Fabrics gets DB access in
+September 2026.
+
+## Orphaned Projects
+
+| Project Name | Origin |
+|---|---|
+| `IIGCONTAINERMGMT[24.204.0004][R19]1` | IIG Container Management ISV |
+| `IIGHFContainerMods[24.204.0004][R04]` | IIG HF Container Modifications |
+| `AesthetikContainerGIs` | Internal — duplicated AesthetikContainers GIs |
+
+## Cleanup SQL
+
+Run against the Heritage Fabrics production database after obtaining access.
+
+**IMPORTANT:** Take a database backup before running. Test on sandbox first.
+
+```sql
+-- Step 1: Identify orphan rows
+SELECT CompanyID, Name, Level, IsPublished
+FROM CustProject
+WHERE Name IN (
+    'IIGCONTAINERMGMT[24.204.0004][R19]1',
+    'IIGHFContainerMods[24.204.0004][R04]',
+    'AesthetikContainerGIs'
+);
+
+-- Step 2: Delete orphan project metadata (cascade to related tables)
+DELETE FROM CustProjectMeta WHERE ProjectID IN (
+    SELECT ProjectID FROM CustProject WHERE Name IN (
+        'IIGCONTAINERMGMT[24.204.0004][R19]1',
+        'IIGHFContainerMods[24.204.0004][R04]',
+        'AesthetikContainerGIs'
+    )
+);
+
+DELETE FROM CustPublishedProject WHERE Name IN (
+    'IIGCONTAINERMGMT[24.204.0004][R19]1',
+    'IIGHFContainerMods[24.204.0004][R04]',
+    'AesthetikContainerGIs'
+);
+
+DELETE FROM CustProject WHERE Name IN (
+    'IIGCONTAINERMGMT[24.204.0004][R19]1',
+    'IIGHFContainerMods[24.204.0004][R04]',
+    'AesthetikContainerGIs'
+);
+
+-- Step 3: Verify cleanup
+SELECT COUNT(*) AS remaining FROM CustProject
+WHERE Name LIKE 'IIG%' OR Name = 'AesthetikContainerGIs';
+-- Expected: 0
+```
+
+## After Cleanup
+
+1. Remove `--no-merge` from deploy.py invocations in `acuops-deploy.yml`
+2. Remove `no_merge_expected` section from `acuops.yaml`
+3. Remove `--no-merge-expected` flag from verify.py invocations in workflow
+4. Test a publish with `isMergeWithExistingPackages=true` on sandbox first
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/reference/iig-orphan-cleanup.md
+git commit -m "docs: IIG orphan cleanup SQL for September DB access
+
+Ready-to-run SQL DELETE statements for the three orphaned CustProject
+rows that force --no-merge mode. Test on sandbox before running on prod."
+```
+
+---
+
+## Workstream 3: Sandbox Entity Sync
+
+### Task 3.1: Make entity-sync.py accept target instance via CLI args
+
+**Files:**
+- Modify: `scripts/heritage/entity-sync.py`
+
+**Step 1: Add argparse CLI**
+
+Currently the script takes no arguments and reads env vars only. Add argparse so it can be invoked as:
+```bash
+python scripts/heritage/entity-sync.py --target sandbox
+```
+
+Add at the top of `main()`:
+```python
+    parser = argparse.ArgumentParser(description="Sync entities from prod to target instance")
+    parser.add_argument(
+        "--target", choices=["test", "sandbox"], default="test",
+        help="Target instance: 'test' (Heritage Test tenant on prod) or 'sandbox' (separate sandbox instance)",
+    )
+    args = parser.parse_args()
+```
+
+For `--target sandbox`, read target credentials from:
+- `SANDBOX_URL` (env var, maps to `ACUMATICA_SANDBOX_URL` in GH Actions)
+- `SANDBOX_USERNAME` / `SANDBOX_PASSWORD` / `SANDBOX_TENANT`
+
+For `--target test` (existing default), keep current behavior: same prod URL, different tenant.
+
+**Step 2: Add PurchaseOrder and Shipment to ENTITY_CONFIG**
+
+Add after the existing SalesOrder entry:
+```python
+    {
+        "name": "PurchaseOrder",
+        "key_field": "OrderNbr",
+        "expand": None,
+        "select": None,
+        "write": True,
+    },
+    {
+        "name": "Shipment",
+        "key_field": "ShipmentNbr",
+        "expand": None,
+        "select": None,
+        "write": True,
+    },
+```
+
+**Step 3: Commit**
+
+```bash
+git add scripts/heritage/entity-sync.py
+git commit -m "feat(entity-sync): add --target sandbox + PurchaseOrder/Shipment entities
+
+Allows syncing prod data to sandbox instance for fresh CRUD/GI testing.
+Adds PO and Shipment entities for container tracking test coverage."
+```
+
+### Task 3.2: Create sandbox sync workflow
+
+**Files:**
+- Create: `.github/workflows/sync-sandbox.yml`
+
+**Step 1: Write the workflow**
+
+```yaml
+name: Sync Sandbox Data
+
+on:
+  schedule:
+    - cron: "23 8 * * *"  # 3:23am ET (after prod→test sync at 2:07am)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (read only, no writes)"
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    name: Entity Sync — Prod → Sandbox
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests pyyaml
+
+      - name: Run entity sync to sandbox
+        env:
+          PYTHONUNBUFFERED: "1"
+          ACUMATICA_URL: ${{ secrets.ACUMATICA_PROD_URL }}
+          ACUMATICA_USERNAME: ${{ secrets.ACUMATICA_PROD_USERNAME }}
+          ACUMATICA_PASSWORD: ${{ secrets.ACUMATICA_PROD_PASSWORD }}
+          PROD_TENANT: "Heritage Fabrics"
+          SANDBOX_URL: ${{ secrets.ACUMATICA_SANDBOX_URL }}
+          SANDBOX_USERNAME: ${{ secrets.ACUMATICA_SANDBOX_USERNAME }}
+          SANDBOX_PASSWORD: ${{ secrets.ACUMATICA_SANDBOX_PASSWORD }}
+          SANDBOX_TENANT: ${{ secrets.ACUMATICA_SANDBOX_TENANT }}
+          SLACK_WEBHOOK_URL: ${{ secrets.STUDIOB_SLACK_WEBHOOK_URL }}
+        run: python scripts/heritage/entity-sync.py --target sandbox
+```
+
+**Step 2: Commit**
+
+```bash
+git add .github/workflows/sync-sandbox.yml
+git commit -m "feat: nightly sandbox entity sync workflow
+
+Runs prod→sandbox entity sync at 3:23am ET (after prod→test at 2:07am).
+Also available via manual workflow_dispatch."
+```
+
+### Task 3.3: Remove skip_on_sandbox from CRUD tests
+
+**Files:**
+- Modify: `tests/ui/test_container_tracking.py`
+
+**Step 1: Remove @skip_on_sandbox decorators**
+
+This task should be done AFTER entity sync has run at least once and sandbox has fresh data. Until then, keep the decorators.
+
+Search for all `@skip_on_sandbox` usages:
+```bash
+grep -n "skip_on_sandbox" tests/ui/test_container_tracking.py
+```
+
+Remove the decorator from:
+- `TestContainerMaintenanceCRUD` (line 512)
+- `TestFreightForwardersCRUD` (line 587)
+- `TestContainerTypesSeedData` (line 608)
+- `TestPortsSeedData` (line 643)
+- `TestContainerPreferencesE2E` (line 672)
+
+**Step 2: Commit**
+
+```bash
+git add tests/ui/test_container_tracking.py
+git commit -m "feat(tests): enable CRUD tests on sandbox (entity sync provides data)"
+```
+
+**NOTE:** Only execute this task after confirming sandbox entity sync has run successfully and sandbox has production-like data.
+
+---
+
+## Execution Order
+
+Tasks can be executed in workstream order (1→2→3). Within each workstream, tasks are sequential.
+
+WS1 and WS2 are independent and could run in parallel. WS3 depends on WS1 being deployed (so PO301000 tests work on sandbox).
+
+Task 3.3 (remove skip_on_sandbox) should be deferred until after the first successful sandbox sync run.

--- a/docs/prompts/2026-04-11-pcc-redesign-session.md
+++ b/docs/prompts/2026-04-11-pcc-redesign-session.md
@@ -1,0 +1,68 @@
+# PCC Redesign — Procurement Command Center + Heritage WMS
+
+**Prior session:** 2026-04-11 Session 5 (sandbox reliability)
+**Session 5 outcome:** PR #353 — PO3010PL fix, --no-merge suppression, sandbox entity sync. Ready for merge.
+
+## Read in order before doing anything
+
+1. `/Users/kevin/.claude/projects/-Users-kevin-dev-acumatica-ci-cd/memory/project_pcc_redesign.md`
+2. `/Users/kevin/.claude/projects/-Users-kevin-dev-acumatica-ci-cd/memory/project_drp_implementation.md`
+3. `/Users/kevin/.claude/projects/-Users-kevin-dev-acumatica-ci-cd/memory/MEMORY.md`
+
+## Context
+
+Kevin confirmed PCC is critical and in scope — not deferred. The sandbox reliability work (PR #353) directly enables PCC:
+- PO3010PL→PO301000 fix means SiteMap navigation works for PO deep-links
+- --no-merge suppression needs expanding when PCC adds SB501100/SB501200 ASPX
+- Sandbox entity sync gives PCC screens real data during testing
+
+## PCC Scope (from memory/project_pcc_redesign.md)
+
+**SB501000 — Procurement Command Center (refactor of Container Maintenance):**
+1. Rename SiteMap title → "Procurement Command Center"
+2. 7-stage lifecycle timeline: PLACED → ACKED → FACTORY READY → SHIPPED → IN TRANSIT → ARRIVED PORT → CUSTOMS → DELIVERED
+3. New LEAD TIME tab (6th) — per-container PO lines with 4-stage breakdown
+4. Upgrade EXPOSURE KPI card — cross-reference drp_recommendations + drp_lead_time_distributions
+5. PLAN NEXT ORDER action on PO LINKS → deep-link to SB501100
+6. KPI retheme (plain ops language): POSITION/CROSS-DOCK/SPECULATION
+7. Keep untouched: COSTS tab, DOCUMENTS tab, ETA HISTORY tab, action ribbon
+
+**SB501100 — Vendor Planning Hub (new screen):**
+- Vendor ranked list + 7-section detail
+
+**SB501200 — Supplier Intake (new screen):**
+- External link to heritage-wms MOQ intake
+
+**Heritage WMS web companion:**
+- heritage-wms Vendors section (aesthetik-platform PR #117) — web-first, ships first
+- Acumatica screens follow when after-hours deploy window allows
+
+## Prerequisites before starting
+
+1. Merge PR #353 (sandbox reliability) — unblocks pipeline
+2. Confirm sandbox-gate passes after merge
+3. Read the locked design doc for PCC sections (§7.1-7.3) — locate in aesthetik-platform or acumatica-ci-cd docs
+
+## Repos in play
+
+- `acumatica-ci-cd` at `/Users/kevin/dev/acumatica-ci-cd/` (Acumatica screens)
+- `aesthetik-platform` at `/Users/kevin/dev/aesthetik-platform/` (heritage-wms web app)
+
+## Deploy constraints
+
+- All three Acumatica screens require after-hours deploy (app pool restart)
+- heritage-wms (Railway) can deploy anytime
+- Web-first: heritage-wms Vendors ships before Acumatica PCC
+
+## Database connection
+
+```
+DATABASE_URL="postgresql://wms:41PNF7MJujb7I0yfikMUYdpV@nozomi.proxy.rlwy.net:38241/heritage_wms"
+```
+Use `/opt/homebrew/Cellar/postgresql@16/16.13/bin/psql` (not in PATH).
+
+## What's NOT in scope
+
+- Phase 2 DRP implementation
+- Exogenous signals (HubSpot, Shopify)
+- Accuracy tracking

--- a/docs/prompts/2026-04-11-sandbox-reliability-session-6.md
+++ b/docs/prompts/2026-04-11-sandbox-reliability-session-6.md
@@ -1,0 +1,60 @@
+# Sandbox Reliability — Session 6 (Post-Merge Verification)
+
+**Prior session:** 2026-04-11 ~1:00 AM ET (Session 5)
+**Session 5 outcome:** PR #353 — 3 workstreams implemented (PO3010PL fix, --no-merge suppression, sandbox entity sync). Not yet merged.
+
+## Read in order before doing anything
+
+1. `/Users/kevin/.claude/projects/-Users-kevin-dev-acumatica-ci-cd/memory/project_drp_implementation.md`
+2. `/Users/kevin/.claude/projects/-Users-kevin-dev-acumatica-ci-cd/memory/MEMORY.md`
+3. `/Users/kevin/dev/acumatica-ci-cd/docs/plans/2026-04-11-sandbox-reliability-design.md`
+
+## Session 5 delivered
+
+| Item | Status |
+|---|---|
+| PR #353 — PO3010PL→PO301000 fix | **Ready for merge** |
+| PR #353 — verify.py --no-merge-expected flag | **Ready for merge** |
+| PR #353 — Sandbox entity sync workflow | **Ready for merge** |
+| IIG orphan cleanup SQL documented | **docs/reference/iig-orphan-cleanup.md** |
+| Access rights (Melanie/Steve/Lauren/Sarah) | **Verified — wildcard covers all** |
+
+## Session 6 priorities
+
+### Priority 1: Merge PR #353 and verify pipeline
+
+1. Merge PR #353 to main
+2. Monitor the AcuOps Deploy pipeline run
+3. Verify sandbox-gate passes (PO301000 tests + verify suppression)
+4. Verify production deploy succeeds
+
+### Priority 2: Run first sandbox entity sync
+
+1. Trigger `sync-sandbox.yml` via workflow_dispatch
+2. Confirm entities synced successfully
+3. If successful, execute Task 3.3: remove `skip_on_sandbox` from CRUD tests
+
+### Priority 3: Diagnose nightly DRP sync failure
+
+The first nightly DRP sync (2026-04-10 06:00 UTC) failed:
+> `Worker did not call orchestrator; GIs not deployed to target Acumatica instance`
+
+This is an aesthetik-platform issue. The OData GIs ARE deployed to production (confirmed 200 in Session 4). Likely the worker is pointing at wrong instance or has stale config.
+
+**Repo:** `/Users/kevin/dev/aesthetik-platform/`
+
+### Priority 4: Refine no_merge_expected list
+
+The `acuops.yaml` currently lists only `aspx:Pages/SB/SB501000.aspx`. After a pipeline run, check the verify output for all 3 ASPX mismatches and add any missing entries.
+
+## Repos in play
+
+- `acumatica-ci-cd` at `/Users/kevin/dev/acumatica-ci-cd/`
+- `aesthetik-platform` at `/Users/kevin/dev/aesthetik-platform/` (DRP sync issue)
+
+## Database connection
+
+```
+DATABASE_URL="postgresql://wms:41PNF7MJujb7I0yfikMUYdpV@nozomi.proxy.rlwy.net:38241/heritage_wms"
+```
+Use `/opt/homebrew/Cellar/postgresql@16/16.13/bin/psql` (not in PATH).

--- a/docs/reference/iig-orphan-cleanup.md
+++ b/docs/reference/iig-orphan-cleanup.md
@@ -1,0 +1,69 @@
+# IIG Orphan Row Cleanup — September 2026
+
+## Context
+
+Three ISV/internal packages were removed from Heritage Fabrics production
+but left orphaned metadata in the Acumatica publish registry. This forces
+`--no-merge` mode (`isMergeWithExistingPackages=false`) for all publishes,
+which skips ASPX extraction for co-published projects.
+
+Acumatica quoted an SOW for cleanup. Heritage Fabrics gets DB access in
+September 2026.
+
+## Orphaned Projects
+
+| Project Name | Origin |
+|---|---|
+| `IIGCONTAINERMGMT[24.204.0004][R19]1` | IIG Container Management ISV |
+| `IIGHFContainerMods[24.204.0004][R04]` | IIG HF Container Modifications |
+| `AesthetikContainerGIs` | Internal — duplicated AesthetikContainers GIs |
+
+## Cleanup SQL
+
+Run against the Heritage Fabrics production database after obtaining access.
+
+**IMPORTANT:** Take a database backup before running. Test on sandbox first.
+
+```sql
+-- Step 1: Identify orphan rows
+SELECT CompanyID, Name, Level, IsPublished
+FROM CustProject
+WHERE Name IN (
+    'IIGCONTAINERMGMT[24.204.0004][R19]1',
+    'IIGHFContainerMods[24.204.0004][R04]',
+    'AesthetikContainerGIs'
+);
+
+-- Step 2: Delete orphan project metadata (cascade to related tables)
+DELETE FROM CustProjectMeta WHERE ProjectID IN (
+    SELECT ProjectID FROM CustProject WHERE Name IN (
+        'IIGCONTAINERMGMT[24.204.0004][R19]1',
+        'IIGHFContainerMods[24.204.0004][R04]',
+        'AesthetikContainerGIs'
+    )
+);
+
+DELETE FROM CustPublishedProject WHERE Name IN (
+    'IIGCONTAINERMGMT[24.204.0004][R19]1',
+    'IIGHFContainerMods[24.204.0004][R04]',
+    'AesthetikContainerGIs'
+);
+
+DELETE FROM CustProject WHERE Name IN (
+    'IIGCONTAINERMGMT[24.204.0004][R19]1',
+    'IIGHFContainerMods[24.204.0004][R04]',
+    'AesthetikContainerGIs'
+);
+
+-- Step 3: Verify cleanup
+SELECT COUNT(*) AS remaining FROM CustProject
+WHERE Name LIKE 'IIG%' OR Name = 'AesthetikContainerGIs';
+-- Expected: 0
+```
+
+## After Cleanup
+
+1. Remove `--no-merge` from deploy.py invocations in `acuops-deploy.yml`
+2. Remove `no_merge_expected` section from `acuops.yaml`
+3. Remove `--no-merge-expected` flag from verify.py invocations in workflow
+4. Test a publish with `isMergeWithExistingPackages=true` on sandbox first

--- a/scripts/heritage/entity-sync.py
+++ b/scripts/heritage/entity-sync.py
@@ -30,6 +30,7 @@ Environment variables (all required):
   SLACK_WEBHOOK_URL      — Incoming webhook for summary notification (optional)
 """
 
+import argparse
 import json
 import os
 import sys
@@ -89,6 +90,20 @@ ENTITY_CONFIG = [
         "expand": None,
         "select": "OrderNbr,OrderType,Status,OrderTotal",
         "write": False,  # Read-only — count comparison
+    },
+    {
+        "name": "PurchaseOrder",
+        "key_field": "OrderNbr",
+        "expand": None,
+        "select": None,
+        "write": True,
+    },
+    {
+        "name": "Shipment",
+        "key_field": "ShipmentNbr",
+        "expand": None,
+        "select": None,
+        "write": True,
     },
 ]
 
@@ -308,13 +323,14 @@ class SyncResult:
 # Slack notification
 # ---------------------------------------------------------------------------
 
-def post_slack_summary(webhook_url: str, results: list[SyncResult]) -> None:
+def post_slack_summary(webhook_url: str, results: list[SyncResult], target: str = "test") -> None:
     """Post a summary to Slack via incoming webhook."""
     total_errors = sum(len(r.errors) for r in results)
     icon = ":white_check_mark:" if total_errors == 0 else ":warning:"
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    target_label = "Sandbox" if target == "sandbox" else "Test"
 
-    lines = [f"{icon} *Entity Sync: Prod → Test* ({ts})", ""]
+    lines = [f"{icon} *Entity Sync: Prod → {target_label}* ({ts})", ""]
     for r in results:
         lines.append(f"  {r.summary_line()}")
 
@@ -342,27 +358,53 @@ def post_slack_summary(webhook_url: str, results: list[SyncResult]) -> None:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
-    _log("=== Acumatica Entity Sync: Production → Test ===", style="bold")
+    parser = argparse.ArgumentParser(description="Sync entities from prod to target instance")
+    parser.add_argument(
+        "--target", choices=["test", "sandbox"], default="test",
+        help="Target instance: 'test' (Heritage Test tenant on prod) or 'sandbox' (separate sandbox instance)",
+    )
+    args = parser.parse_args()
+
+    target_label = "Sandbox" if args.target == "sandbox" else "Test"
+    _log(f"=== Acumatica Entity Sync: Production → {target_label} ===", style="bold")
 
     # Read config from environment
     url = os.environ.get("ACUMATICA_URL", "").rstrip("/")
     username = os.environ.get("ACUMATICA_USERNAME", "")
     password = os.environ.get("ACUMATICA_PASSWORD", "")
     prod_tenant = os.environ.get("PROD_TENANT", "Heritage Fabrics")
-    test_tenant = os.environ.get("TEST_TENANT", "Heritage Test")
     slack_webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
 
     if not all([url, username, password]):
         _log("Missing required env vars: ACUMATICA_URL, ACUMATICA_USERNAME, ACUMATICA_PASSWORD", style="err")
         return 1
 
-    _log(f"Instance: {url}")
+    # Target config: test uses same instance, sandbox uses separate instance
+    if args.target == "sandbox":
+        target_url = os.environ.get("SANDBOX_URL", "").rstrip("/")
+        target_username = os.environ.get("SANDBOX_USERNAME", "")
+        target_password = os.environ.get("SANDBOX_PASSWORD", "")
+        target_tenant = os.environ.get("SANDBOX_TENANT", "")
+        if not all([target_url, target_username, target_password]):
+            _log(
+                "Missing required env vars for sandbox target: "
+                "SANDBOX_URL, SANDBOX_USERNAME, SANDBOX_PASSWORD",
+                style="err",
+            )
+            return 1
+    else:
+        target_url = url
+        target_username = username
+        target_password = password
+        target_tenant = os.environ.get("TEST_TENANT", "Heritage Test")
+
+    _log(f"Source instance: {url}")
     _log(f"Production tenant: {prod_tenant}")
-    _log(f"Test tenant: {test_tenant}")
+    _log(f"Target ({args.target}): {target_url} / {target_tenant or '(default)'}")
 
     # Create clients
     prod = AcumaticaEntityClient(url, username, password, prod_tenant)
-    test = AcumaticaEntityClient(url, username, password, test_tenant)
+    test = AcumaticaEntityClient(target_url, target_username, target_password, target_tenant)
 
     results: list[SyncResult] = []
 
@@ -388,9 +430,9 @@ def main() -> int:
     finally:
         prod.logout()
 
-    # Phase 2: Write to test (separate session — avoids session gate conflict)
+    # Phase 2: Write to target (separate session — avoids session gate conflict)
     _log("")
-    _log("=== Phase 2: Writing to test ===", style="bold")
+    _log(f"=== Phase 2: Writing to {target_label} ===", style="bold")
     try:
         test.login()
         for config in ENTITY_CONFIG:
@@ -486,7 +528,7 @@ def main() -> int:
 
     # Slack notification
     if slack_webhook:
-        post_slack_summary(slack_webhook, results)
+        post_slack_summary(slack_webhook, results, target=args.target)
     else:
         _log("No SLACK_WEBHOOK_URL set — skipping notification", style="warn")
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -686,7 +686,20 @@ def main():
         default=os.environ.get("ACUMATICA_PROJECT", ""),
         help="Customization project name for ASPX verification (env: ACUMATICA_PROJECT)",
     )
+    parser.add_argument(
+        "--no-merge-expected",
+        default=None,
+        help="Path to YAML file with no_merge_expected list of ASPX check names to downgrade FAIL→WARN",
+    )
     args = parser.parse_args()
+
+    # Load --no-merge expected ASPX failures
+    no_merge_expected = set()
+    if args.no_merge_expected:
+        import yaml
+        with open(args.no_merge_expected) as f:
+            config = yaml.safe_load(f)
+        no_merge_expected = set(config.get("no_merge_expected", []))
 
     # Validate required fields
     for field_name in ("url", "username", "password", "tenant"):
@@ -746,6 +759,15 @@ def main():
         ))
     finally:
         session.logout()
+
+    # Downgrade known --no-merge ASPX failures to WARN
+    if no_merge_expected:
+        for check in all_checks:
+            if (check.status == CheckStatus.FAIL
+                    and check.name in no_merge_expected
+                    and "not overwritten by import" in check.detail):
+                check.status = CheckStatus.WARN
+                check.detail += " [expected: --no-merge]"
 
     overall = compute_overall(all_checks)
     summary = build_summary(all_checks)

--- a/tests/ui/test_container_tracking.py
+++ b/tests/ui/test_container_tracking.py
@@ -169,6 +169,14 @@ class TestPO301000ContainerFields:
         btn = acumatica_page.locator("text=CONTAINER TRACKING")
         assert btn.count() > 0, "CONTAINER TRACKING button not found on PO301000"
 
+    @pytest.mark.skipif(
+        "sandbox" in ACUMATICA_URL.lower(),
+        reason="PO3010PL SiteMap shadow forces direct-ASPX load, which "
+        "bypasses the Main iframe shell. PXAction button redirects "
+        "require the shell framework — clicks navigate to error when "
+        "loaded directly. Button existence is verified by "
+        "test_container_tracking_button_exists.",
+    )
     def test_container_tracking_navigates_to_sb501000(self, acumatica_page):
         """Clicking CONTAINER TRACKING should navigate to SB501000 without error.
 

--- a/tests/ui/test_container_tracking.py
+++ b/tests/ui/test_container_tracking.py
@@ -142,63 +142,27 @@ class TestPO301000ContainerFields:
         screen = acumatica_screen("PO301000")
         screen.assert_no_errors()
 
-    def test_container_tracking_button_exists(self, acumatica_page):
-        """CONTAINER TRACKING toolbar button should be present.
+    def test_container_tracking_button_exists(self, acumatica_screen):
+        """CONTAINER TRACKING toolbar button should be present on PO301000."""
+        screen = acumatica_screen("PO301000")
+        screen.page.wait_for_timeout(3_000)
 
-        The button is rendered by POOrderEntry_Extension.viewContainer
-        (PXAction with DisplayName='Container Tracking') on the PO form.
-
-        Uses Pattern B (direct-aspx + 3 s wait) from KB article
-        acumatica-iframe-screenshadow-test-patterns.md:
-        - PO301000 is shadowed in SiteMap (ScreenID="PO3010PL"), so
-          /Main?ScreenId=PO301000 redirects to home and the iframe never
-          loads the PO form.
-        - AcumaticaScreen.direct() waits for the form container but NOT
-          for toolbar render; PXAction buttons are injected by JS after
-          domcontentloaded. The 3 s wait allows the toolbar to render.
-        - page.locator() operates on the top-level document only and does
-          NOT pierce iframes, so direct-aspx (no iframe wrapper) is correct
-          here. btn.count() is immediate — must wait before calling it.
-        """
-        acumatica_page.goto(
-            f"{ACUMATICA_URL}/Pages/PO/PO301000.aspx",
-            wait_until="domcontentloaded",
-        )
-        acumatica_page.wait_for_timeout(3_000)
-
-        btn = acumatica_page.locator("text=CONTAINER TRACKING")
+        btn = screen.page.locator("text=CONTAINER TRACKING")
         assert btn.count() > 0, "CONTAINER TRACKING button not found on PO301000"
 
-    @pytest.mark.skipif(
-        "sandbox" in ACUMATICA_URL.lower(),
-        reason="PO3010PL SiteMap shadow forces direct-ASPX load, which "
-        "bypasses the Main iframe shell. PXAction button redirects "
-        "require the shell framework — clicks navigate to error when "
-        "loaded directly. Button existence is verified by "
-        "test_container_tracking_button_exists.",
-    )
-    def test_container_tracking_navigates_to_sb501000(self, acumatica_page):
-        """Clicking CONTAINER TRACKING should navigate to SB501000 without error.
+    def test_container_tracking_navigates_to_sb501000(self, acumatica_screen):
+        """Clicking CONTAINER TRACKING should navigate to SB501000 without error."""
+        screen = acumatica_screen("PO301000")
+        screen.page.wait_for_timeout(3_000)
 
-        Uses direct ASPX URL (same as test_container_tracking_button_exists)
-        because PO301000 is shadowed in SiteMap (ScreenID="PO3010PL") and
-        acumatica_screen("PO301000") redirects to home via Main?ScreenId=.
-        """
-        acumatica_page.goto(
-            f"{ACUMATICA_URL}/Pages/PO/PO301000.aspx",
-            wait_until="domcontentloaded",
-        )
-        acumatica_page.wait_for_timeout(3_000)
-
-        btn = acumatica_page.locator("text=CONTAINER TRACKING").first
+        btn = screen.page.locator("text=CONTAINER TRACKING").first
         if btn.is_visible(timeout=3000):
             btn.click()
-            acumatica_page.wait_for_load_state("domcontentloaded")
-            acumatica_page.wait_for_timeout(3000)
+            screen.page.wait_for_load_state("domcontentloaded")
+            screen.page.wait_for_timeout(3000)
 
-        # Should land on SB501000 or stay on PO301000, NOT error page
-        assert "ScreenId=ERROR" not in acumatica_page.url, \
-            f"CONTAINER TRACKING button caused error. URL: {acumatica_page.url}"
+        assert "ScreenId=ERROR" not in screen.page.url, \
+            f"CONTAINER TRACKING button caused error. URL: {screen.page.url}"
 
 
 class TestIGCMScreensRemoved:


### PR DESCRIPTION
## Summary
Three workstreams to fix sandbox-gate reliability:

**WS1: PO3010PL SiteMap Shadow**
- Changed `ScreenID="PO3010PL"` → `"PO301000"` in AesthetikWMS project.xml
- Reverted all direct-ASPX test workarounds back to `acumatica_screen` fixture
- Removed `skipif(sandbox)` decorator from navigation test
- Access rights verified: wildcard `*` role grants Melanie/Steve/Lauren (SB501000) and Sarah (PO302000) access

**WS2: --no-merge Verify Suppression**
- Added `no_merge_expected` list to `acuops.yaml`
- Added `--no-merge-expected` flag to `verify.py` — downgrades known ASPX mismatches FAIL→WARN
- Wired flag into all 4 verify.py invocations in `acuops-deploy.yml`
- Documented IIG orphan cleanup SQL for September DB access (`docs/reference/iig-orphan-cleanup.md`)

**WS3: Sandbox Data Freshness**
- Extended `entity-sync.py` with `--target sandbox` flag + PurchaseOrder/Shipment entities
- Created `sync-sandbox.yml` workflow (nightly 3:23am ET + manual dispatch)

## Deferred
- Task 3.3: Remove `skip_on_sandbox` from CRUD tests — after first successful sandbox sync

## Test plan
- [ ] Pipeline runs sandbox-gate: PO301000 tests pass via SiteMap navigation (no direct ASPX)
- [ ] verify.py downgrades known ASPX mismatches to WARN (not FAIL)
- [ ] Sandbox sync workflow runs successfully (manual dispatch test)
- [ ] All container tracking tests pass (65+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)