### PR TITLE
fix: remove duplicate DataMember on Lead Time PXGrid

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -257,7 +257,7 @@
                     <px:PXTabItem Text="Lead Time">
                         <Template>
                             <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
-                                Width="100%" SkinID="Details" DataMember="LeadTimes">
+                                Width="100%" SkinID="Details">
                                 <Levels>
                                     <px:PXGridLevel DataMember="LeadTimes">
                                         <Columns>

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -473,7 +473,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                     <px:PXTabItem Text="Lead Time">
                         <Template>
                             <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
-                                Width="100%" SkinID="Details" DataMember="LeadTimes">
+                                Width="100%" SkinID="Details">
                                 <Levels>
                                     <px:PXGridLevel DataMember="LeadTimes">
                                         <Columns>


### PR DESCRIPTION
## Summary
- Removes `DataMember="LeadTimes"` from `PXGrid` element — it belongs only on `PXGridLevel`
- Fixes `ASPPARSE: The 'DataMember' property cannot be set declaratively` error that failed sandbox publish in PR #358

## Test Plan
- [ ] Sandbox publish succeeds
- [ ] Lead Time tab loads on SB501000

🤖 Generated with [Claude Code](https://claude.com/claude-code)