### PR TITLE
fix: verify.py traverse nested $adHocSchema for custom field checks

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -257,7 +257,7 @@
                     <px:PXTabItem Text="Lead Time">
                         <Template>
                             <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
-                                Width="100%" SkinID="Details" DataMember="LeadTimes">
+                                Width="100%" SkinID="Details">
                                 <Levels>
                                     <px:PXGridLevel DataMember="LeadTimes">
                                         <Columns>

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -473,7 +473,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                     <px:PXTabItem Text="Lead Time">
                         <Template>
                             <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
-                                Width="100%" SkinID="Details" DataMember="LeadTimes">
+                                Width="100%" SkinID="Details">
                                 <Levels>
                                     <px:PXGridLevel DataMember="LeadTimes">
                                         <Columns>

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -281,7 +281,10 @@ def check_custom_fields(
     results = []
     for f in fields:
         short_name = f.split(".")[-1]
-        if f in schema:
+        # Navigate dotted path (e.g. "custom.Document.UsrExpArrivalDate")
+        # through the nested schema dict
+        found = _resolve_dotted_path(schema, f)
+        if found:
             results.append(CheckResult(
                 name=f"field:{entity}.{short_name}",
                 status=CheckStatus.PASS,
@@ -296,6 +299,26 @@ def check_custom_fields(
                 http_code=status,
             ))
     return results
+
+
+def _resolve_dotted_path(obj: dict, dotted_path: str) -> bool:
+    """Walk a dotted path like 'custom.Document.UsrFoo' through nested dicts.
+
+    Returns True if the final key exists at the expected depth.
+    Also checks flat key as fallback for forward-compatibility.
+    """
+    # Fast path: flat key exists (original behavior)
+    if dotted_path in obj:
+        return True
+    # Walk nested path
+    parts = dotted_path.split(".")
+    current = obj
+    for part in parts:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return False
+    return True
 
 
 def run_e2e_probe(


### PR DESCRIPTION
## Summary
- `check_custom_fields` in verify.py was doing flat key lookup (`"custom.Document.UsrFoo" in schema`) but `$adHocSchema` returns nested JSON (`schema["custom"]["Document"]["UsrFoo"]`)
- This bug meant PurchaseOrder custom field checks (UsrExpArrivalDate, UsrActArrivalDate, UsrContainerRef) always failed — they just never ran on main until the PCC deploy triggered the sandbox gate
- Fix: `_resolve_dotted_path()` walks the dotted path through nested dicts, with flat-key fallback

## Test Plan
- [ ] Sandbox gate passes for PurchaseOrder custom fields
- [ ] Manually verified fields present on sandbox via `$adHocSchema` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)