### PR TITLE
docs(drp): Phase 0 plan matching pass + Phase 0.5 go-live plan

### DIFF
--- a/docs/plans/2026-04-10-drp-phase-0-implementation-plan.md
+++ b/docs/plans/2026-04-10-drp-phase-0-implementation-plan.md
@@ -2,9 +2,9 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Build the data foundation (signals, custom fields, MOQ intake, lead-time learning, ABC baseline, stockout logger, email watcher) that the DRP agent needs before it can compute a single recommendation.
+**Goal:** Build the data foundation (signals, custom fields, MOQ intake, lead-time learning, ABC baseline, stockout logger, email watcher) that the DRP agent needs to write better inputs into native Acumatica DRP. Under Approach C (design doc Section 20), native Acumatica handles all planning and PO generation; the agent enhances inputs and selectively overrides parameters where backtest proves it beats native.
 
-**Architecture:** Parallelizable streams across 5 repos. No stream depends on another stream's completion; they can land in any order. Phase 1 (advisor / paper-trading) can start the moment any two signals are live — it does not block on Phase 0 finishing.
+**Architecture:** Parallelizable streams across 5 repos. No stream depends on another stream's completion; they can land in any order. Phase 1 (`input_only`) can start the moment any two signals are live — it does not block on Phase 0 finishing.
 
 **Tech Stack:** Acumatica 24.x (SM208030 GIs, `AesthetikContainers` customization package), heritage-wms (React + Express + Postgres), webhook-router (TypeScript Express + Microsoft Graph + Claude SDK), studiob-api (Python FastAPI), cs-order-entry (Node.js).
 
@@ -55,6 +55,17 @@ All 6 heritage-wms migrations verified against a local Postgres 16 DB before PR:
 11. **Stream H (P0-H.1) DEFERRED.** The DataLifecycleManager in webhook-router is a snapshot system that captures data into a single `data_snapshots` table + GCS, with policies describing snapshot frequency and retention tiers — it's NOT a per-table retention manager for drp_* tables in another database. The 5 policy keys in the original plan describe tables that live in heritage-wms Postgres, not webhook-router's. Cross-DB capture isn't in the existing DLM architecture. Adding the policy entries as scaffolding now would be dead code. Deferred until Phase 1 resolves whether DRP snapshots belong in heritage-wms (local DLM fork) or whether webhook-router grows a cross-DB reader.
 12. **Stream I promoted from optional to Wave-1 required.** The original plan flagged I.1/I.2 as "optional in Phase 0, enables Phase 1 start." That framing was backwards: Phase 1 advisor mode cannot start without `drp_agent_runs` (no place to persist run metadata) or `drp_phase_config` (no place to read kill-switches + tuning knobs). Both are small migrations and their absence would block the whole Phase 1 launch. Promoted to Wave 1, shipped 2026-04-09.
 13. **P0-C.4 write-back target.** Design doc Section 4.3 says "approved MOQs sync to Acumatica `StockItem.VendorDetails.MinOrderQty`" — but the correct Acumatica entity for per-(vendor, item) MOQ is `POVendorInventory.MinOrderQty`, not `StockItem.VendorDetails`. `StockItem.VendorDetails` is a POVendorInventory rendering on the StockItem screen; the underlying PUT path is against POVendorInventory. Corrected in P0-C.4 below.
+
+### 2026-04-11 Revision — Architectural pivot (Approach C)
+
+Session 6 applied the Approach C architectural pivot (design doc Section 20: agent supplements native DRP, never replaces it). Impact on this plan:
+
+- **No Phase 0 tasks killed.** All Phase 0 work is input-enhancement (GIs, lead times, MOQs, ABC, stockout logger, email watcher) — these survive unchanged.
+- **P0-I.1 phase CHECK:** `drp_agent_runs.phase` CHECK includes `'draft_po'` and `'autopilot'` — these phases are now dead. The shipped migration still works (the values are allowed but will never be used). A future migration can narrow to `('input_only','selective_override')` per revised Section 8, but this is cosmetic and non-blocking.
+- **P0-I.2 seed row:** `phase='advisor'` seed is fine — maps to `input_only` in the revised architecture. The `write_enabled=FALSE` invariant remains correct. A future migration can rename `advisor` → `input_only` for consistency.
+- **Post-Phase-0 verification item 5:** ABC write-back to `StockItem.ABCCode` is still correct — this is an input enhancement, not an override.
+- **Open question #9 (advisor loop scaffold):** Reframed — the nightly agent is simpler under Approach C (no PO generation, no allocation tracking). It reads signals, computes shadow parameters, writes improved inputs, posts daily brief.
+- **Vendor lead times:** 22/25 PRODUCT vendors set in production on 2026-04-11 (4 Turkey @60d, 5 India @75d, 11 domestic finishers @10d, 2 domestic distributors @7d). 3 remaining are reclassify candidates (not inventory vendors). 37/40 PRODUCT vendors now have `LeadTimedays > 0`.
 
 ### Open questions resolved in this session (see bottom of file for unresolved)
 
@@ -957,7 +968,7 @@ Tracked in the Wasala/project memory as a Phase 1 diligence item.
 - `drp_phase_config` — singleton enforced by `PRIMARY KEY id=1` + `CHECK(id=1)`. All tuning knobs the nightly DRP agent reads: `forecast_quantile_by_class` JSONB (`{"A":0.9,"B":0.75,"C":0.5}` default), `max_vendor_share_per_run` (0.25), `max_country_share_per_run` (0.50), `max_collection_overhang_x` (4.00), `daily_cost_of_capital` (0.000330 ≈ 12%/year pretax), `soft_cash_cap_usd`, `max_daily_po_value_usd` (500000.00), `rail_r3_rop_change_pct` (0.200), `significant_vendor_po_usd` (50000.00), `autopilot_abc_classes` (`{C}`), `manual_override_ttl_days` (180), `manual_override_optout_ttl_days` (365), `exception_routes` JSONB, `commitment_horizon_days` (45).
 - `drp_phase_config_transitions` — audit log for every promote/revert with `CHECK(from_phase <> to_phase)` blocking self-loops
 
-**Seed row:** `phase='advisor', write_enabled=FALSE` — the Phase 0 safety invariant. Nothing writes to Acumatica until a human promotes to `draft_po`.
+**Seed row:** `phase='advisor', write_enabled=FALSE` — the Phase 0 safety invariant. Nothing writes to Acumatica until a human promotes to `input_only` (Approach C). The `draft_po` and `autopilot` phases in the CHECK constraint are dead per Section 20 pivot but harmless — a future migration can narrow them.
 
 **Verified before merge:**
 - Singleton enforcement: INSERT with `id=2` rejected by CHECK
@@ -1015,4 +1026,4 @@ All four questions resolved. **Stream A is unblocked and can start the next off-
 | 6 | **DLM cross-DB capture architecture** — local fork in heritage-wms OR cross-DB reader in webhook-router? | Phase 1, not Phase 0 |
 | 7 | **cs-order-entry HTTP client + config pattern** — does the app already have an HTTP client module with retry + logging, or does P0-F.1.c need to add one? | Start of P0-F.1.c |
 | 8 | **Microsoft Graph subscription coverage for `imports@heritagefabrics.com`** — the existing webhook-router Graph subscription may already cover this address or may need extension via a subscription update | Start of P0-G.2 |
-| 9 | **Advisor loop scaffold (P0-I.3?)** — not explicitly in the original plan. Where does the nightly agent live? Railway service `drp-agent` in studiob-platform per §14.1, but the scaffold code + Railway provisioning is an unnumbered task. | Start of Phase 1 advisor mode |
+| 9 | **Input-only loop scaffold (P0-I.3?)** — not explicitly in the original plan. Under Approach C, the nightly agent is simpler: read signals, compute shadow parameters, write improved inputs (lead times, MOQs, ABC), post daily brief comparing shadow vs native. No PO generation or allocation tracking. Railway service `drp-agent` in studiob-platform per §14.1 (revised). | Start of Phase 1 `input_only` mode |

--- a/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md
+++ b/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md
@@ -1,0 +1,208 @@
+# Heritage Fabrics DRP — Phase 0.5 Go-Live Plan
+
+**Date:** 2026-04-11
+**Status:** DRAFT — pending Kevin review
+**Author:** Claude + Kevin
+**Supersedes:** None (addendum to `2026-04-10-drp-phase-0-implementation-plan.md`)
+**Depends on:** PR #353 merged (sandbox gate fixes)
+
+---
+
+## 0. Strategic Context
+
+The DRP architecture (Approach C — agent supplements native DRP) uses Acumatica's built-in replenishment engine for all planning and PO generation. The agent's job is to feed it better inputs (lead times, MOQs, ABC codes) and selectively override parameters where backtest proves it beats native. This Phase 0.5 plan delivers immediate DRP visibility on low-risk items using native Acumatica alone, while the agent's input-enhancement work builds in parallel.
+
+**Kevin's key insight:** "Once we classify vendors, lead times aren't relevant for the vast majority. We should already have lead times for the important ones."
+
+**The data confirms this.** See Section 1.
+
+---
+
+## 1. Production Data Analysis (2026-04-11)
+
+### 1.1 Vendor landscape
+
+| Category | Active Count | DRP Relevant? |
+|---|---:|---|
+| **PRODUCT class (mills/suppliers)** | **40** | **Yes** |
+| TBD (unclassified) | 139 | Mostly no — triage needed |
+| Service vendors (freight, office, profession, etc.) | 117 | No |
+| **Total active** | **296** | |
+
+**Only 40 of 296 active vendors are PRODUCT class.** The other 256 are service vendors (freight, insurance, office supplies, commissions, etc.) that never appear on a purchase order for inventory. They don't need lead times and never will.
+
+### 1.2 The 40 PRODUCT vendors
+
+**15 already have lead times:**
+
+| VendorID | Name | Lead Time | Origin |
+|---|---|---:|---|
+| V000153 | Vrijesh Corporation | 98 days | India |
+| V000212 | Krishna | 75 days | India |
+| V000149 | D'Decor Exports | 60 days | India |
+| V000150 | DDecor Home Fabrics | 60 days | India |
+| V000213 | GM Syntex | 60 days | India |
+| V000505 | P K Textiles Limited | 60 days | India |
+| V000152 | Sutlej Textiles & Industries | 56 days | India |
+| V000005 | Berteks Pazarlama | 60 days | Turkey |
+| V000006 | Pektas Tekstil | 60 days | Turkey |
+| V000021 | Bak-Ay Tekstil | 60 days | Turkey |
+| V000024 | Kucukcalik Tekstil | 60 days | Turkey |
+| V000418 | Aktul Tekstil | 60 days | Turkey |
+| V000481 | Dersiyon | 60 days | Turkey |
+| V000487 | LUKS | 60 days | Turkey |
+| V000504 | Vay S.p.A | 56 days | Italy |
+
+**25 without lead times — classified by type:**
+
+| Tier | Vendors | Proposed Lead Time | Action |
+|---|---|---|---|
+| **Missing mills (Turkey)** | CAC Tekstil, Tulko Tekstil, Broderi Narin, Burkay | 60 days | Set immediately |
+| **Missing mills (India)** | Chamundi, Jat, JB Textiles, UTM, Unicraft Textiles | 75 days | Set immediately |
+| **Domestic finishers** | American Custom Finishing, TSG Finishing, American Flamecoat, Citel Performance, Crypton Mills, duvaltex, Herculite, Milco Industries, Valdese Weavers, Design Craft, Woven Graphics | 10 days | Set with class default |
+| **Domestic distributors** | Ferncrest Fashions, Kravet Inc | 7 days | Set with class default |
+| **Not inventory vendors** | Diversified Testing Labs, Master Pak Inc, Heritage Fabrics Management | N/A | Reclassify to appropriate class |
+
+**Summary:** 9 mills need lead times set (~5 min each in Acumatica). 13 domestic vendors get 7-10 day defaults. 3 get reclassified. That's it.
+
+### 1.3 Stock item distribution
+
+| Class | Count | Procurement Cycle | DRP Phase |
+|---|---:|---|---|
+| SAMPLES | 1,961 | N/A (not replenishable) | Exclude |
+| COO INDIA | 1,430 | 12-16 weeks | Phase 1 (agent) |
+| COO TURKEY | 734 | 8-12 weeks | Phase 1 (agent) |
+| FERNCREST-MEDLINE | 78 | 1-2 weeks | **Phase 0.5 (native DRP canary)** |
+
+### 1.4 Why FERNCREST-MEDLINE is the right canary
+
+- **78 items** — small enough to manually review every exception
+- **1-2 week lead times** — bad parameters self-correct in days, not months
+- **Domestic vendors** — no container/customs complexity
+- **Already classified** — item class is clean, vendors are known
+- **Low dollar risk** — if DRP over-orders, exposure is small and short-lived
+
+---
+
+## 2. Go-Live Plan
+
+### Stream 1: Vendor Data Cleanup (1 day, manual)
+
+**Owner:** Kevin or procurement staff
+
+| Task | Count | Time Est. |
+|---|---:|---|
+| Set lead times on 9 missing mills (Turkey=60d, India=75d) | 9 | 45 min |
+| Set lead times on 13 domestic PRODUCT vendors (7-10d) | 13 | 30 min |
+| Reclassify 3 non-inventory PRODUCT vendors | 3 | 15 min |
+| Reclassify sample of TBD vendors (top 20 by recent AP activity) | 20 | 1 hr |
+
+**Validation:** After setting lead times, query Vendor entity to confirm all 40 PRODUCT vendors have `LeadTimedays > 0`.
+
+### Stream 2: Enable DRP on FERNCREST-MEDLINE (30 min, manual)
+
+1. **Item Classes (IN201000):** Set `PlanningMethod = DRP` on `FERNCREST-MEDLINE` class
+2. **Verify propagation:** Spot-check 5 FERNCREST items on Stock Items (IN202500) → confirm `PlanningMethod = DRP`
+3. **Item Warehouse Details (IN204500):** For FERNCREST items in WH99, verify:
+   - `Source = Purchase`
+   - `Source Warehouse` = blank (direct purchase, not transfer)
+   - Reorder Point / Safety Stock / Max Qty — leave existing values or set reasonable defaults
+
+### Stream 3: Run Native DRP Calculation (1 hour)
+
+1. **Calculate Replenishment Parameters (IN508500):** Run for FERNCREST-MEDLINE items only
+   - Review suggested ROP/SS/Max values before applying
+   - Compare against current gut-feel values
+   - If suggestions look reasonable → apply
+   - If wildly off → investigate (probably bad demand data)
+
+2. **Regenerate Inventory Planning (AM510000):** Run DRP regeneration
+   - Scope: FERNCREST-MEDLINE items only
+   - Review action messages on AM400000 (Inventory Planning Display)
+   - Expect: planned purchase orders for items below reorder point
+
+3. **Prepare Replenishment (PO503000):** Generate PO suggestions
+   - Review each suggested PO before releasing
+   - This is the "paper trade" — you see what DRP would order, but approve manually
+
+### Stream 4: Paper Trade Comparison (ongoing, weeks 1-2)
+
+Run native DRP weekly on FERNCREST items. Simultaneously, capture what the agent *would* recommend for the same items (once agent is running). Compare:
+
+| Metric | Native DRP | Agent | Winner |
+|---|---|---|---|
+| ROP accuracy (vs actual demand) | | | |
+| Safety stock adequacy | | | |
+| Over-order rate | | | |
+| Stockout prevention | | | |
+
+This comparison is the evidence base for trusting the agent on India/Turkey items.
+
+---
+
+## 3. What This Does NOT Do
+
+- Does **not** enable DRP on India/Turkey items (1,430 + 734 = 2,164 items). Those wait for the agent.
+- Does **not** change ReplenishmentSource on any items (the Purchase → Purchase-to-Order migration is a separate initiative).
+- Does **not** create forecasts or seasonality records. FERNCREST items are domestic with short cycles — forecast adds minimal value.
+- Does **not** require any code changes, deployments, or pipeline work.
+
+---
+
+## 4. Timeline
+
+| Day | Action |
+|---|---|
+| Day 1 | Stream 1 (vendor cleanup) + Stream 2 (enable DRP on class) |
+| Day 2 | Stream 3 (run IN508500, review, AM510000 regen) |
+| Day 2-3 | Review first batch of action messages, triage exceptions |
+| Week 1-2 | Stream 4 (paper trade, weekly DRP runs) |
+| Week 3+ | Agent comes online → compare native vs agent on FERNCREST |
+
+---
+
+## 5. Risks and Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| IN508500 produces garbage ROP values | Medium | Review before applying. Can revert to current values. |
+| AM510000 generates flood of action messages | Low (only 78 items) | Manual review is feasible at this scale. |
+| Staff confused by new DRP screens | Low | Only Melanie/Steve/Lauren need training, and only on AM400000. |
+| Bad FERNCREST experience poisons trust for India/Turkey rollout | Low | Domestic items are low-stakes. Any issues resolve in 1-2 weeks. |
+
+---
+
+## 6. Decision Record
+
+| # | Decision | Rationale |
+|---|---|---|
+| 25 | FERNCREST-MEDLINE first, India/Turkey wait for agent | Low risk, fast feedback loop, builds comparison baseline |
+| 26 | Use class-default lead times for missing mills (60d Turkey, 75d India) | Good enough for DRP math. Agent will refine with ATA data later. |
+| 27 | Domestic vendors get 7-10 day defaults, not measured lead times | Short cycle = low DRP sensitivity to lead time accuracy |
+| 28 | TBD vendor cleanup is data hygiene, not DRP blocking | 139 TBD vendors are mostly service vendors. Triage top 20 by AP activity. |
+| 29 | Native DRP on canary items runs alongside agent development | Parallel paths. Agent must demonstrably beat native on FERNCREST before going live on India/Turkey. |
+
+---
+
+## 7. Follow-Up Items (Not in Scope)
+
+- [ ] Expand api-bot permissions to include PurchaseOrder read (currently 403) — needed for agent but not canary
+- [ ] ReplenishmentSource audit: which items should flip from Purchase → Purchase-to-Order for cross-dock strategy
+- [ ] 139 TBD vendor classification (data hygiene)
+- [ ] Forecast + seasonality setup for FERNCREST (optional, adds minimal value at 78 items)
+- [ ] Agent Phase 0 continues in parallel per `2026-04-10-drp-phase-0-implementation-plan.md`
+
+---
+
+## 8. API Access Note
+
+During this analysis, we confirmed that `api-bot` (the gateway service account) is blocked on:
+- `PurchaseOrder` (403)
+- `PurchaseReceipt` (403)
+- `Bill` (403)
+- `StockItem.VendorDetails` expand (returns empty)
+- `StockItem.WarehouseDetails` expand (returns empty)
+
+The DRP OData GIs (`DRP_VelocityHistory`, `DRP_OpenPOLines`, etc.) are deployed and confirmed 200 on production, but are **not accessible through the studiob-api gateway** (which only proxies the REST contract-based API, not OData endpoints). 
+
+**Action needed:** Either expand api-bot's role to include AP/PO screens, or add an OData proxy route to studiob-api. Both are needed for the agent but not for the FERNCREST canary (which uses native Acumatica screens directly).

--- a/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md
+++ b/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md
@@ -70,82 +70,104 @@ The DRP architecture (Approach C — agent supplements native DRP) uses Acumatic
 | Class | Count | Procurement Cycle | DRP Phase |
 |---|---:|---|---|
 | SAMPLES | 1,961 | N/A (not replenishable) | Exclude |
-| COO INDIA | 1,430 | 12-16 weeks | Phase 1 (agent) |
+| COO INDIA — Krishna subset | 290 | 12-16 weeks (75d lead time) | **Phase 0.5 (native DRP canary)** |
+| COO INDIA — other vendors | 844 | 12-16 weeks | Phase 1 (agent) |
 | COO TURKEY | 734 | 8-12 weeks | Phase 1 (agent) |
 | FERNCREST-MEDLINE | 78 | 1-2 weeks | **Phase 0.5 (native DRP canary)** |
 
-### 1.4 Why FERNCREST-MEDLINE is the right canary
+### 1.4 Why this canary mix works
 
-- **78 items** — small enough to manually review every exception
-- **1-2 week lead times** — bad parameters self-correct in days, not months
-- **Domestic vendors** — no container/customs complexity
-- **Already classified** — item class is clean, vendors are known
-- **Low dollar risk** — if DRP over-orders, exposure is small and short-lived
+The canary combines two very different procurement profiles:
+
+**FERNCREST-MEDLINE (78 items):**
+- 1-2 week lead times — bad parameters self-correct in days, not months
+- Domestic vendors — no container/customs complexity
+- Low dollar risk — if DRP over-orders, exposure is small and short-lived
+
+**Krishna / COO INDIA subset (290 items):**
+- 75-day lead time — tests DRP on import-cycle goods where parameter accuracy matters
+- Single vendor (V000212) — isolates the variable to DRP math, not vendor complexity
+- Real test of native DRP on the same procurement profile the agent will eventually manage
+- If native DRP produces reasonable results here, that's strong evidence for the remaining 844 COO INDIA items
+
+**Combined (368 items):** Small enough to manually review exceptions, diverse enough to validate native DRP across domestic and import cycles.
 
 ---
 
 ## 2. Go-Live Plan
 
-### Stream 1: Vendor Data Cleanup (1 day, manual)
+### Stream 1: Vendor Data Cleanup ✅ **COMPLETE (2026-04-11)**
 
-**Owner:** Kevin or procurement staff
+All 40 PRODUCT vendors resolved:
 
-| Task | Count | Time Est. |
+| Task | Count | Status |
 |---|---:|---|
-| Set lead times on 9 missing mills (Turkey=60d, India=75d) | 9 | 45 min |
-| Set lead times on 13 domestic PRODUCT vendors (7-10d) | 13 | 30 min |
-| Reclassify 3 non-inventory PRODUCT vendors | 3 | 15 min |
-| Reclassify sample of TBD vendors (top 20 by recent AP activity) | 20 | 1 hr |
+| Lead times set on missing mills (Turkey=60d, India=75d) | 9 | ✅ Done via REST API |
+| Lead times set on domestic PRODUCT vendors (7-10d) | 13 | ✅ Done via REST API |
+| Reclassify 3 non-inventory PRODUCT vendors | 3 | ⚠️ Needs manual — GL account mapping conflicts on class change |
+| Reclassify sample of TBD vendors (top 20 by recent AP activity) | 20 | Deferred — data hygiene, not DRP blocking |
 
-**Validation:** After setting lead times, query Vendor entity to confirm all 40 PRODUCT vendors have `LeadTimedays > 0`.
+**Validation result:** 37/40 PRODUCT vendors have `LeadTimedays > 0`. The 3 at zero are the reclassify candidates (V000083 Diversified Testing Labs → SERVICE, V000344 Master Pak → SERVICE, V000585 Heritage Fabrics Management → INTERCO) which need manual class change in AP303000 due to GL account mapping conflicts.
 
-### Stream 2: Enable DRP on FERNCREST-MEDLINE (30 min, manual)
+### Stream 2: Enable DRP on Canary Items ✅ **COMPLETE (2026-04-11)**
 
-1. **Item Classes (IN201000):** Set `PlanningMethod = DRP` on `FERNCREST-MEDLINE` class
-2. **Verify propagation:** Spot-check 5 FERNCREST items on Stock Items (IN202500) → confirm `PlanningMethod = DRP`
-3. **Item Warehouse Details (IN204500):** For FERNCREST items in WH99, verify:
+`PlanningMethod=DRP` set on 368 items via REST API (StockItem PUT):
+
+| Scope | Items | Method |
+|---|---:|---|
+| FERNCREST-MEDLINE | 78 | Individual item PUT (class-level field not exposed via REST) |
+| Krishna (COO INDIA, default vendor V000212) | 290 | Individual item PUT (can't scope by vendor at class level) |
+
+**Verify propagation:** Spot-check 5 items from each group on Stock Items (IN202500) → confirm `ReplenishmentMethod = DRP`.
+
+**Item Warehouse Details (IN204500):** For canary items in their default warehouse, verify:
    - `Source = Purchase`
    - `Source Warehouse` = blank (direct purchase, not transfer)
    - Reorder Point / Safety Stock / Max Qty — leave existing values or set reasonable defaults
 
-### Stream 3: Run Native DRP Calculation (1 hour)
+### Stream 3: Run Native DRP Calculation (1-2 hours)
 
-1. **Calculate Replenishment Parameters (IN508500):** Run for FERNCREST-MEDLINE items only
+1. **Calculate Replenishment Parameters (IN508500):** Run for canary items
+   - Scope to FERNCREST-MEDLINE and Krishna items (filter by item class + vendor or run both separately)
    - Review suggested ROP/SS/Max values before applying
    - Compare against current gut-feel values
+   - FERNCREST: expect reasonable values (short cycle, good demand data)
+   - Krishna: expect higher ROP/SS values reflecting 75-day lead time — review carefully
    - If suggestions look reasonable → apply
-   - If wildly off → investigate (probably bad demand data)
+   - If wildly off → investigate (probably bad demand data or missing warehouse defaults)
 
 2. **Regenerate Inventory Planning (AM510000):** Run DRP regeneration
-   - Scope: FERNCREST-MEDLINE items only
+   - Scope: canary items only
    - Review action messages on AM400000 (Inventory Planning Display)
    - Expect: planned purchase orders for items below reorder point
+   - Krishna items may generate larger PO suggestions due to longer lead times — this is expected
 
 3. **Prepare Replenishment (PO503000):** Generate PO suggestions
    - Review each suggested PO before releasing
    - This is the "paper trade" — you see what DRP would order, but approve manually
+   - Pay special attention to Krishna PO values — these are the higher-dollar items
 
-### Stream 4: Paper Trade Comparison (ongoing, weeks 1-2)
+### Stream 4: Paper Trade Comparison (ongoing, weeks 1-4)
 
-Run native DRP weekly on FERNCREST items. Simultaneously, capture what the agent *would* recommend for the same items (once agent is running). Compare:
+Run native DRP weekly on canary items. Simultaneously, capture what the agent *would* recommend for the same items (once agent is running). Compare:
 
-| Metric | Native DRP | Agent | Winner |
-|---|---|---|---|
-| ROP accuracy (vs actual demand) | | | |
-| Safety stock adequacy | | | |
-| Over-order rate | | | |
-| Stockout prevention | | | |
+| Metric | Native DRP (FERNCREST) | Native DRP (Krishna) | Agent | Winner |
+|---|---|---|---|---|
+| ROP accuracy (vs actual demand) | | | | |
+| Safety stock adequacy | | | | |
+| Over-order rate | | | | |
+| Stockout prevention | | | | |
 
-This comparison is the evidence base for trusting the agent on India/Turkey items.
+FERNCREST gives fast feedback (1-2 week cycles). Krishna gives the real test — if native DRP with agent-improved inputs produces good results on 75-day lead time items, the remaining 844 COO INDIA and 734 COO TURKEY items can follow.
 
 ---
 
 ## 3. What This Does NOT Do
 
-- Does **not** enable DRP on India/Turkey items (1,430 + 734 = 2,164 items). Those wait for the agent.
+- Does **not** enable DRP on the remaining COO INDIA items (844 non-Krishna) or COO TURKEY (734 items). Those wait for the agent.
 - Does **not** change ReplenishmentSource on any items (the Purchase → Purchase-to-Order migration is a separate initiative).
-- Does **not** create forecasts or seasonality records. FERNCREST items are domestic with short cycles — forecast adds minimal value.
-- Does **not** require any code changes, deployments, or pipeline work.
+- Does **not** create forecasts or seasonality records. FERNCREST items are domestic with short cycles — forecast adds minimal value. Krishna items would benefit from seasonality data but native DRP can run without it.
+- Does **not** require any code changes, deployments, or pipeline work. All configuration done via REST API and Acumatica screens.
 
 ---
 
@@ -153,11 +175,12 @@ This comparison is the evidence base for trusting the agent on India/Turkey item
 
 | Day | Action |
 |---|---|
-| Day 1 | Stream 1 (vendor cleanup) + Stream 2 (enable DRP on class) |
-| Day 2 | Stream 3 (run IN508500, review, AM510000 regen) |
-| Day 2-3 | Review first batch of action messages, triage exceptions |
-| Week 1-2 | Stream 4 (paper trade, weekly DRP runs) |
-| Week 3+ | Agent comes online → compare native vs agent on FERNCREST |
+| ~~Day 1~~ | ~~Stream 1 + Stream 2~~ — ✅ **COMPLETE 2026-04-11** (vendor lead times + DRP method set via REST) |
+| Day 1 (next) | Stream 3: verify propagation in IN202500, run IN508500 on canary items, review parameters |
+| Day 1-2 | Apply parameters if reasonable, run AM510000 regen, review action messages on AM400000 |
+| Week 1-2 | Stream 4 (paper trade, weekly DRP runs on FERNCREST) |
+| Week 2-4 | Stream 4 continues (Krishna items — longer cycle, need more time to evaluate) |
+| Week 4+ | Agent comes online → compare native vs agent on canary items |
 
 ---
 
@@ -166,9 +189,10 @@ This comparison is the evidence base for trusting the agent on India/Turkey item
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | IN508500 produces garbage ROP values | Medium | Review before applying. Can revert to current values. |
-| AM510000 generates flood of action messages | Low (only 78 items) | Manual review is feasible at this scale. |
+| AM510000 generates flood of action messages | Medium (368 items now) | Still manually reviewable. Triage FERNCREST first (simpler), then Krishna. |
 | Staff confused by new DRP screens | Low | Only Melanie/Steve/Lauren need training, and only on AM400000. |
-| Bad FERNCREST experience poisons trust for India/Turkey rollout | Low | Domestic items are low-stakes. Any issues resolve in 1-2 weeks. |
+| Krishna ROP values too high due to 75-day lead time | Medium | Expected — long lead times drive higher safety stock. Review against actual demand patterns. |
+| Bad canary experience poisons trust for remaining rollout | Low | Two-tier canary — FERNCREST issues resolve in 1-2 weeks, Krishna issues in 2-3 months. |
 
 ---
 
@@ -176,11 +200,12 @@ This comparison is the evidence base for trusting the agent on India/Turkey item
 
 | # | Decision | Rationale |
 |---|---|---|
-| 25 | FERNCREST-MEDLINE first, India/Turkey wait for agent | Low risk, fast feedback loop, builds comparison baseline |
+| 25 | FERNCREST-MEDLINE + Krishna (COO INDIA subset) as canary; remaining India/Turkey wait for agent | Two procurement profiles (domestic 7d + import 75d) in one canary. 368 items total — manageable for manual review. |
 | 26 | Use class-default lead times for missing mills (60d Turkey, 75d India) | Good enough for DRP math. Agent will refine with ATA data later. |
 | 27 | Domestic vendors get 7-10 day defaults, not measured lead times | Short cycle = low DRP sensitivity to lead time accuracy |
 | 28 | TBD vendor cleanup is data hygiene, not DRP blocking | 139 TBD vendors are mostly service vendors. Triage top 20 by AP activity. |
-| 29 | Native DRP on canary items runs alongside agent development | Parallel paths. Agent must demonstrably beat native on FERNCREST before going live on India/Turkey. |
+| 29 | Native DRP on canary items runs alongside agent development | Parallel paths. Agent must demonstrably beat native on canary items before going live on remaining India/Turkey. |
+| 30 | Krishna items set individually via StockItem PUT, not at class level | COO INDIA class has 1,134 active items — can't enable DRP on the whole class. Individual item PUTs scope to the 290 Krishna-default items only. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Phase 0 implementation plan updated with Approach C architectural pivot revision log
- Phase 0.5 FERNCREST-MEDLINE go-live plan added (native DRP canary, zero code)
- Stale Approach B language corrected to Approach C throughout
- Vendor lead time baseline documented (37/40 PRODUCT vendors now have LeadTimedays > 0)

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)