### PR TITLE
fix: detail panel sync + KPI metrics row (SB501000)

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -76,8 +76,8 @@
                     </px:PXGridLevel>
                 </Levels>
                 <AutoSize Enabled="True" MinHeight="200" />
-                <AutoCallBack Command="Refresh" Target="frmDetail" ActiveBehavior="True">
-                    <Behavior RepaintControlsIDs="frmTimeline,frmDetail,tabDetail" />
+                <AutoCallBack Target="frmDetail" ActiveBehavior="True">
+                    <Behavior RepaintControlsIDs="frmTimeline,frmDetail,tabDetail" CommitChanges="True" />
                 </AutoCallBack>
             </px:PXGrid>
         </Template1>
@@ -85,7 +85,7 @@
             <%-- 2026-04-08: Phase D — Status timeline strip + grouped detail form.
                  Timeline rendered via PXHtmlView bound to UsrContainer.TimelineHtml,
                  populated in ContainerMaint.RowSelected<UsrContainer>. --%>
-            <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Containers"
+            <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Container"
                 Width="100%" CaptionVisible="False" RenderStyle="Simple" SkinID="Transparent">
                 <Template>
                     <%-- 2026-04-08: explicit layout rule so the hidden edTabLabelsJson
@@ -102,7 +102,7 @@
                         SuppressLabel="True" Style="display:none;" />
                 </Template>
             </px:PXFormView>
-            <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Containers"
+            <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
                 Width="100%" CaptionVisible="False">
                 <Template>
                     <%-- Group 1: Identity --%>

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -292,8 +292,8 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                     </px:PXGridLevel>
                 </Levels>
                 <AutoSize Enabled="True" MinHeight="200" />
-                <AutoCallBack Command="Refresh" Target="frmDetail" ActiveBehavior="True">
-                    <Behavior RepaintControlsIDs="frmTimeline,frmDetail,tabDetail" />
+                <AutoCallBack Target="frmDetail" ActiveBehavior="True">
+                    <Behavior RepaintControlsIDs="frmTimeline,frmDetail,tabDetail" CommitChanges="True" />
                 </AutoCallBack>
             </px:PXGrid>
         </Template1>
@@ -301,7 +301,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
             <%-- 2026-04-08: Phase D — Status timeline strip + grouped detail form.
                  Timeline rendered via PXHtmlView bound to UsrContainer.TimelineHtml,
                  populated in ContainerMaint.RowSelected<UsrContainer>. --%>
-            <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Containers"
+            <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Container"
                 Width="100%" CaptionVisible="False" RenderStyle="Simple" SkinID="Transparent">
                 <Template>
                     <%-- 2026-04-08: explicit layout rule so the hidden edTabLabelsJson
@@ -318,7 +318,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                         SuppressLabel="True" Style="display:none;" />
                 </Template>
             </px:PXFormView>
-            <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Containers"
+            <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
                 Width="100%" CaptionVisible="False">
                 <Template>
                     <%-- Group 1: Identity --%>

--- a/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
@@ -390,6 +390,18 @@ window.sb501000ApplyRiskRowColors = function() {
   } catch(e) { console.error('sb501000ApplyRiskRowColors failed', e); }
 };
 
+// Auto-resize the PXHtmlView iframe to fit all content (tiles + metrics row).
+// Acumatica's PXHtmlView renders content in an iframe that defaults to 150px,
+// which clips the metrics row below the tile cards.
+(function() {
+  try {
+    if (window.frameElement) {
+      var h = document.body.scrollHeight;
+      if (h > 0) window.frameElement.style.height = h + 'px';
+    }
+  } catch(e) {}
+})();
+
 // Run on initial load and after every grid refresh. Acumatica's grid fires
 // updates through px_alls events; the simplest robust approach is to poll on
 // a short interval until the grid is settled, then re-run on any click within
@@ -398,6 +410,14 @@ window.sb501000ApplyRiskRowColors = function() {
   var applyAll = function() {
     if (window.sb501000ApplyRiskRowColors) window.sb501000ApplyRiskRowColors();
     if (window.sb501000ApplyTabLabels) window.sb501000ApplyTabLabels();
+    // Re-check iframe sizing in case KPI content changed
+    try {
+      if (window.frameElement) {
+        var h = document.body.scrollHeight;
+        if (h > 0 && window.frameElement.clientHeight < h)
+          window.frameElement.style.height = h + 'px';
+      }
+    } catch(e) {}
   };
   var count = 0;
   var tick = setInterval(function() {

--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -23,6 +23,15 @@ namespace StudioB.Containers
 
         public SelectFrom<UsrContainer>.View Container;
 
+        // Delegate: return only the grid-selected container so frmDetail/frmTimeline
+        // don't re-execute the full containers() delegate and reset Current.
+        protected virtual IEnumerable container()
+        {
+            UsrContainer current = Containers.Current;
+            if (current != null)
+                yield return current;
+        }
+
         public SelectFrom<UsrContainerEvent>
             .Where<UsrContainerEvent.containerID.IsEqual<UsrContainer.containerID.FromCurrent>>
             .OrderBy<UsrContainerEvent.eventDateTime.Desc>


### PR DESCRIPTION
## Summary
- **Bug 1 (detail sync):** Clicking different containers in the grid now properly updates the Identity section, Timeline, and tab data. Root cause was `Command="Refresh"` on the AutoCallBack re-executing the `containers()` delegate and resetting `Current` to the first row. Fixed by removing the Command, adding a `container()` delegate that returns only `Containers.Current`, and binding frmDetail/frmTimeline to the `Container` view.
- **Bug 2 (metrics row):** The OPEN PO VALUE / CROSS-DOCK RATE / UNCOVERED VALUE row below KPI tiles was invisible because PXHtmlView's iframe defaults to 150px height while content needs ~250px. Fixed by adding JS to auto-resize the iframe via `window.frameElement.style.height`.

## Test plan
- [ ] Click 3+ different containers in grid — verify Identity (Container Nbr, Status, Carrier) updates each time
- [ ] Verify Timeline strip updates to show correct lifecycle stage per container
- [ ] Verify tab data (Events, PO Links, Costs) updates per container
- [ ] Verify metrics row (OPEN PO VALUE / CROSS-DOCK RATE / UNCOVERED VALUE) is visible below KPI tiles
- [ ] Verify KPI tile click handlers still work (click ACTION/WATCH/EXPOSURE to filter grid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)