### PR TITLE
fix: SelectSingleBound compile fix for container delegate (SB501000)

### DIFF
--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -34,7 +34,7 @@ namespace StudioB.Containers
             {
                 current = SelectFrom<UsrContainer>
                     .OrderBy<UsrContainer.eta.Asc>
-                    .View.SelectSingle(this);
+                    .View.SelectSingleBound(this, null);
             }
             if (current != null)
                 yield return current;


### PR DESCRIPTION
## Summary
- Fix CS0120 compile error from #372: `SelectSingle` is an instance method, replaced with `SelectSingleBound(this, null)` which is the correct static call pattern for BQL in delegate methods

## Test plan
- [ ] Build passes
- [ ] SB501000 loads with first container data in detail panel
- [ ] Click rows to verify sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)