### PR TITLE
fix: deploy tag push permission + correct DRP screen IDs

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -113,7 +113,7 @@ on:
         default: ''
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   pull-requests: write
 

--- a/docs/plans/2026-04-09-drp-implementation-design.md
+++ b/docs/plans/2026-04-09-drp-implementation-design.md
@@ -99,7 +99,7 @@ Class names already encode the long-cycle reality. This intelligence isn't yet w
 | Decision | Value | Notes |
 |---|---|---|
 | ~~**Approach**~~ | ~~B — External forecasting agent writes to Acumatica~~ | ~~Agent is the brain; Acumatica is the system of record~~ |
-| **Approach (revised)** | **C — Hybrid: agent enhances native DRP inputs, native engine does the planning** | Agent writes better lead times, MOQs, ABC codes. Native IN508500 → AM510000 → PO503000 handles planning + PO generation. Agent overrides ROP/SS/Max only where backtest proves it beats native. |
+| **Approach (revised)** | **C — Hybrid: agent enhances native DRP inputs, native engine does the planning** | Agent writes better lead times, MOQs, ABC codes. Native IN508500 → AM505000 → PO503000 handles planning + PO generation. Agent overrides ROP/SS/Max only where backtest proves it beats native. |
 | **Objective function** | Minimize inventory dollar-days, subject to committed fill-rate floor | Not service-level maximization |
 | **Primary metric** | Cross-dock hit rate (% of receipts shipped within 7d) | Plus turns/year, dead inventory $, days of cover |
 | **Service level floor** | 98% committed / 90% speculative | Floor, not target |
@@ -155,7 +155,7 @@ Class names already encode the long-cycle reality. This intelligence isn't yet w
                                      │                 │
                                      │ NATIVE DRP:     │
                                      │ • IN508500 calc │
-                                     │ • AM510000 regen│
+                                     │ • AM505000 regen│
                                      │ • AM400000 view │
                                      │ • PO503000 POs  │
                                      │ • PO301000 aprv │
@@ -842,7 +842,7 @@ Brief rendering reuses the Slack canvas primitives already in webhook-router.
 
 Native DRP workflow (no agent involvement):
 1. IN508500 computes replenishment parameters (using agent-improved inputs)
-2. AM510000 regenerates action messages
+2. AM505000 regenerates action messages
 3. Staff reviews action messages on AM400000
 4. PO503000 converts approved action messages to draft POs
 5. Staff reviews and releases POs on PO301000
@@ -1077,7 +1077,7 @@ Design changes after this point go through RFCs appended as Section 18+ amendmen
 
 The original design (Approach B, "agent is the brain") positioned the DRP agent as a complete replacement for Acumatica's native replenishment engine. The agent would compute forecasts, generate PO recommendations, create draft POs, track PO-to-SO allocations, and eventually auto-release C-item POs.
 
-**Revised design (Approach C, "agent supplements native DRP"):** The agent enhances native DRP's *inputs* (lead times, MOQs, ABC codes) and selectively overrides native DRP's *outputs* (ROP/SS/Max) only where backtest evidence proves the agent beats native. The agent never creates POs, never tracks allocations, and never enters the PO approval workflow. Native Acumatica screens (IN508500, AM510000, AM400000, PO503000, PO301000) handle the full planning-to-PO pipeline.
+**Revised design (Approach C, "agent supplements native DRP"):** The agent enhances native DRP's *inputs* (lead times, MOQs, ABC codes) and selectively overrides native DRP's *outputs* (ROP/SS/Max) only where backtest evidence proves the agent beats native. The agent never creates POs, never tracks allocations, and never enters the PO approval workflow. Native Acumatica screens (IN508500, AM505000, AM400000, PO503000, PO301000) handle the full planning-to-PO pipeline.
 
 ### 20.2 Why
 

--- a/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md
+++ b/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md
@@ -136,7 +136,7 @@ All 40 PRODUCT vendors resolved:
    - If suggestions look reasonable → apply
    - If wildly off → investigate (probably bad demand data or missing warehouse defaults)
 
-2. **Regenerate Inventory Planning (AM510000):** Run DRP regeneration
+2. **Regenerate Inventory Planning (AM505000):** Run DRP regeneration
    - Scope: canary items only
    - Review action messages on AM400000 (Inventory Planning Display)
    - Expect: planned purchase orders for items below reorder point
@@ -177,7 +177,7 @@ FERNCREST gives fast feedback (1-2 week cycles). Krishna gives the real test —
 |---|---|
 | ~~Day 1~~ | ~~Stream 1 + Stream 2~~ — ✅ **COMPLETE 2026-04-11** (vendor lead times + DRP method set via REST) |
 | Day 1 (next) | Stream 3: verify propagation in IN202500, run IN508500 on canary items, review parameters |
-| Day 1-2 | Apply parameters if reasonable, run AM510000 regen, review action messages on AM400000 |
+| Day 1-2 | Apply parameters if reasonable, run AM505000 regen, review action messages on AM400000 |
 | Week 1-2 | Stream 4 (paper trade, weekly DRP runs on FERNCREST) |
 | Week 2-4 | Stream 4 continues (Krishna items — longer cycle, need more time to evaluate) |
 | Week 4+ | Agent comes online → compare native vs agent on canary items |
@@ -189,7 +189,7 @@ FERNCREST gives fast feedback (1-2 week cycles). Krishna gives the real test —
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | IN508500 produces garbage ROP values | Medium | Review before applying. Can revert to current values. |
-| AM510000 generates flood of action messages | Medium (368 items now) | Still manually reviewable. Triage FERNCREST first (simpler), then Krishna. |
+| AM505000 generates flood of action messages | Medium (368 items now) | Still manually reviewable. Triage FERNCREST first (simpler), then Krishna. |
 | Staff confused by new DRP screens | Low | Only Melanie/Steve/Lauren need training, and only on AM400000. |
 | Krishna ROP values too high due to 75-day lead time | Medium | Expected — long lead times drive higher safety stock. Review against actual demand patterns. |
 | Bad canary experience poisons trust for remaining rollout | Low | Two-tier canary — FERNCREST issues resolve in 1-2 weeks, Krishna issues in 2-3 months. |

--- a/docs/prompts/2026-04-11-drp-architectural-pivot-continuation.md
+++ b/docs/prompts/2026-04-11-drp-architectural-pivot-continuation.md
@@ -14,7 +14,7 @@
 
 ## What the pivot changed
 
-**Core principle:** Native Acumatica DRP (IN508500 → AM510000 → AM400000 → PO503000 → PO301000) is the planning engine. The agent writes better inputs and selectively overrides parameters where backtest earns it. The agent NEVER creates POs, tracks allocations, or enters the approval workflow.
+**Core principle:** Native Acumatica DRP (IN508500 → AM505000 → AM400000 → PO503000 → PO301000) is the planning engine. The agent writes better inputs and selectively overrides parameters where backtest earns it. The agent NEVER creates POs, tracks allocations, or enters the approval workflow.
 
 **Killed:**
 - `drp_po_allocations` table (not yet built)

--- a/docs/prompts/2026-04-11-drp-phase-0.5-canary-live-continuation.md
+++ b/docs/prompts/2026-04-11-drp-phase-0.5-canary-live-continuation.md
@@ -6,7 +6,7 @@
 
 ## Read in order before doing anything
 
-1. `/Users/kevin/dev/acumatica-ci-cd/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md` — Streams 1-2 COMPLETE, Stream 3 (IN508500/AM510000) is next
+1. `/Users/kevin/dev/acumatica-ci-cd/docs/plans/2026-04-11-drp-phase-0.5-go-live-plan.md` — Streams 1-2 COMPLETE, Stream 3 (IN508500/AM505000) is next
 2. `/Users/kevin/dev/acumatica-ci-cd/docs/plans/2026-04-09-drp-implementation-design.md` — Section 20 (architectural pivot)
 3. `/Users/kevin/dev/acumatica-ci-cd/docs/plans/2026-04-10-drp-phase-0-implementation-plan.md` — Remaining ~9 code tasks
 4. `/Users/kevin/.claude/projects/-Users-kevin-dev-acumatica-ci-cd/memory/project_drp_implementation.md` — Current project state
@@ -32,7 +32,7 @@
 
 1. **Verify DRP propagation** — spot-check 5 items from each group in IN202500, confirm ReplenishmentMethod=DRP
 2. **Run IN508500** (Calculate Replenishment Parameters) scoped to canary items — review ROP/SS/Max suggestions before applying
-3. **Run AM510000** (Regenerate Inventory Planning) — generates action messages
+3. **Run AM505000** (Regenerate Inventory Planning) — generates action messages
 4. **Review AM400000** (Inventory Planning Display) — paper trade: see what DRP would order
 5. **3 vendor reclassifications** — manual in AP303000, REST blocked by GL account conflicts:
    - V000083 DIVERSIFIED TESTING LABORATORIES → SERVICE
@@ -41,7 +41,7 @@
 
 ### Soon — deploy + remaining Phase 0 code
 
-6. **Off-hours deploy** — PR #356 (DAC restriction group fix) is merged but not deployed. AesthetikContainers publish required (app pool restart). This makes DRP GIs return data for non-admin users.
+6. **Off-hours deploy — PR #356 merged and likely deployed (run 24293585717 succeeded through publish+verify, but tagged as failed due to git tag push 403). Confirm GI access works for non-admin users.
 
 7. **Verify nightly DRP sync** — PR #126 merged. Next run is 2:00 AM ET. Confirm `drp_agent_runs` row completes with status=complete, not stuck as running.
 


### PR DESCRIPTION
## Summary
- Grant `contents: write` permission to acuops-deploy workflow so the "Tag successful deploy" step can push git tags (was failing with 403)
- Fix hallucinated screen ID `AM510000` (actually "Create Production Orders") → correct `AM505000` ("Regenerate Inventory Planning") across all 4 DRP docs
- Update Phase 0.5 continuation prompt to reflect PR #356 deploy status

## Test plan
- [ ] Next production deploy should tag successfully without 403
- [ ] Verify AM505000 is accessible in Acumatica Manufacturing module

🤖 Generated with [Claude Code](https://claude.com/claude-code)