### PR TITLE
fix(pcc): remove invalid AfterRowDblClick ASPX property

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -80,7 +80,6 @@
         <AutoCallBack Command="Refresh" Target="frmTimeline" ActiveBehavior="True">
             <Behavior RepaintControlsIDs="frmTimeline" CommitChanges="True" />
         </AutoCallBack>
-        <ClientEvents AfterRowDblClick="sb501000OnGridDblClick" />
     </px:PXGrid>
 
     <%-- Slide-out detail panel (right-anchored) --%>

--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -20,16 +20,11 @@
             <px:PXDSCallbackCommand Name="RecordETAUpdate" CommitChanges="True" Visible="False" />
             <px:PXDSCallbackCommand Name="PlanNextOrder" CommitChanges="True" StartNewGroup="True" />
             <px:PXDSCallbackCommand Name="ImportForwarderCSV" CommitChanges="True" StartNewGroup="True" />
+            <px:PXDSCallbackCommand Name="OpenContainerDetail" CommitChanges="True" Visible="False" />
         </CallbackCommands>
     </px:PXDataSource>
 </asp:Content>
 <asp:Content ID="cont2" ContentPlaceHolderID="phF" Runat="Server">
-    <%-- 2026-04-07: Command Center redesign — RFC 1 Phase B
-         Replaces the four edKPI* number-edit fields with a single PXHtmlView
-         bound to Filter.KPITilesHtml. The graph populates the HTML string in
-         RowSelected<ContainerFilter> via ContainerKPITileBuilder.
-         See docs/plans/2026-04-07-sb501000-kpi-tile-approved.md for the spec.
-    --%>
     <px:PXFormView ID="frmFilter" runat="server" DataSourceID="ds" DataMember="Filter"
         Width="100%" AllowAutoHide="false" CaptionVisible="False" RenderStyle="Simple"
         SkinID="Transparent">
@@ -37,287 +32,267 @@
             <px:PXLayoutRule ID="PXLayoutRule1" runat="server" StartRow="True" />
             <px:PXHtmlView ID="htmlKPITiles" runat="server" DataField="KPITilesHtml"
                 Height="280px" Width="100%" SkinID="Label" />
-            <%-- Hidden field backing the tile click handlers. sb501000SetViewMode()
-                 in the embedded JS writes to this field, then postData() refreshes
-                 the grid with the new filter. --%>
             <px:PXDropDown ID="edViewMode" runat="server" DataField="ViewMode"
                 CommitChanges="True" Style="display:none;" />
         </Template>
     </px:PXFormView>
+    <%-- Timeline Command Bar — updates on grid row click --%>
+    <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Container"
+        Width="100%" CaptionVisible="False" RenderStyle="Simple" SkinID="Transparent">
+        <Template>
+            <px:PXLayoutRule runat="server" StartRow="True" />
+            <px:PXHtmlView ID="htmlTimeline" runat="server" DataField="TimelineHtml"
+                Height="90px" Width="100%" SkinID="Label" />
+            <px:PXTextEdit ID="edTabLabelsJson" runat="server" DataField="TabLabelsJson"
+                SuppressLabel="True" Style="display:none;" />
+        </Template>
+    </px:PXFormView>
 </asp:Content>
 <asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
-    <px:PXSplitContainer ID="splitMain" runat="server" Orientation="Vertical" SplitterPosition="400">
-        <AutoSize Enabled="True" Container="Window" />
-        <Template1>
-            <px:PXGrid ID="gridContainers" runat="server" DataSourceID="ds"
-                Width="100%" SkinID="Inquire" SyncPosition="True"
-                AllowPaging="True" AdjustPageSize="Auto" NoteIndicator="False" FilesIndicator="False">
-                <Levels>
-                    <px:PXGridLevel DataMember="Containers">
-                        <Columns>
-                            <%-- 2026-04-07: Phase C — Risk indicator + operational columns.
-                                 The Risk column is a one-letter code (R/A/G) that JS in
-                                 ContainerGridRowColorScript maps to row-level CSS classes. --%>
-                            <px:PXGridColumn DataField="RiskLevel" Width="30" TextAlign="Center" />
-                            <px:PXGridColumn DataField="ContainerCD" Width="120" />
-                            <px:PXGridColumn DataField="Status" Width="110" />
-                            <px:PXGridColumn DataField="TransportMode" Width="70" />
-                            <px:PXGridColumn DataField="CarrierCode" Width="80" />
-                            <px:PXGridColumn DataField="VesselName" Width="120" />
-                            <px:PXGridColumn DataField="ETA" Width="90" />
-                            <px:PXGridColumn DataField="ATA" Width="90" />
-                            <px:PXGridColumn DataField="LastFreeDay" Width="90" />
-                            <px:PXGridColumn DataField="DaysToLFD" Width="60" TextAlign="Right" />
-                            <px:PXGridColumn DataField="DocsSummary" Width="60" TextAlign="Center" />
-                            <px:PXGridColumn DataField="DemurrageExposure" Width="100" TextAlign="Right" />
-                            <px:PXGridColumn DataField="PortOfDischarge" Width="90" />
-                            <px:PXGridColumn DataField="LastEventCode" Width="100" />
-                        </Columns>
-                    </px:PXGridLevel>
-                </Levels>
-                <AutoSize Enabled="True" MinHeight="200" />
-                <AutoCallBack Command="Refresh" Target="frmDetail" ActiveBehavior="True">
-                    <Behavior RepaintControlsIDs="frmTimeline,frmDetail,tabDetail" CommitChanges="True" />
-                </AutoCallBack>
-            </px:PXGrid>
-        </Template1>
-        <Template2>
-            <%-- 2026-04-08: Phase D — Status timeline strip + grouped detail form.
-                 Timeline rendered via PXHtmlView bound to UsrContainer.TimelineHtml,
-                 populated in ContainerMaint.RowSelected<UsrContainer>. --%>
-            <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Container"
-                Width="100%" CaptionVisible="False" RenderStyle="Simple" SkinID="Transparent">
-                <Template>
-                    <%-- 2026-04-08: explicit layout rule so the hidden edTabLabelsJson
-                         below doesn't render a "Tab Labels:" label cell. Without this,
-                         PXFormView auto-layout wraps the field in a label-column +
-                         value-column row and Style="display:none;" only hits the
-                         inner input, leaving the label visible. Pattern mirrors
-                         frmFilter which correctly hides edViewMode the same way. --%>
-                    <px:PXLayoutRule runat="server" StartRow="True" />
-                    <px:PXHtmlView ID="htmlTimeline" runat="server" DataField="TimelineHtml"
-                        Height="90px" Width="100%" SkinID="Label" />
-                    <%-- Hidden field carrying tab label JSON for the JS updater --%>
-                    <px:PXTextEdit ID="edTabLabelsJson" runat="server" DataField="TabLabelsJson"
-                        SuppressLabel="True" Style="display:none;" />
-                </Template>
-            </px:PXFormView>
-            <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
-                Width="100%" CaptionVisible="False">
-                <Template>
-                    <%-- Group 1: Identity --%>
-                    <px:PXLayoutRule ID="lrIdentity" runat="server" StartColumn="True"
-                        StartGroup="True" GroupCaption="Identity" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXSelector ID="edContainerCD" runat="server" DataField="ContainerCD" Enabled="False" />
-                    <px:PXDropDown ID="edStatus" runat="server" DataField="Status" CommitChanges="True" />
-                    <px:PXTextEdit ID="edCarrierCode" runat="server" DataField="CarrierCode" />
-                    <px:PXDropDown ID="edTransportMode" runat="server" DataField="TransportMode" />
-                    <px:PXTextEdit ID="edVesselName" runat="server" DataField="VesselName" />
-                    <px:PXTextEdit ID="edSealNbr" runat="server" DataField="SealNbr" />
+    <%-- Full-width container grid --%>
+    <px:PXGrid ID="gridContainers" runat="server" DataSourceID="ds"
+        Width="100%" SkinID="Inquire" SyncPosition="True"
+        AllowPaging="True" AdjustPageSize="Auto" NoteIndicator="False" FilesIndicator="False">
+        <Levels>
+            <px:PXGridLevel DataMember="Containers">
+                <Columns>
+                    <px:PXGridColumn DataField="RiskLevel" Width="30" TextAlign="Center" />
+                    <px:PXGridColumn DataField="ContainerCD" Width="120" LinkCommand="OpenContainerDetail" />
+                    <px:PXGridColumn DataField="Status" Width="110" />
+                    <px:PXGridColumn DataField="TransportMode" Width="70" />
+                    <px:PXGridColumn DataField="CarrierCode" Width="80" />
+                    <px:PXGridColumn DataField="VesselName" Width="120" />
+                    <px:PXGridColumn DataField="ETA" Width="90" />
+                    <px:PXGridColumn DataField="ATA" Width="90" />
+                    <px:PXGridColumn DataField="LastFreeDay" Width="90" />
+                    <px:PXGridColumn DataField="DaysToLFD" Width="60" TextAlign="Right" />
+                    <px:PXGridColumn DataField="DemurrageExposure" Width="100" TextAlign="Right" />
+                    <px:PXGridColumn DataField="FactoryPromisedDate" Width="90" />
+                    <px:PXGridColumn DataField="FactoryActualDate" Width="90" />
+                    <px:PXGridColumn DataField="MillAckDate" Width="90" />
+                    <px:PXGridColumn DataField="DocsSummary" Width="60" TextAlign="Center" />
+                    <px:PXGridColumn DataField="PortOfDischarge" Width="90" />
+                    <px:PXGridColumn DataField="LastEventCode" Width="100" />
+                </Columns>
+            </px:PXGridLevel>
+        </Levels>
+        <AutoSize Enabled="True" MinHeight="300" Container="Window" />
+        <AutoCallBack Command="Refresh" Target="frmTimeline" ActiveBehavior="True">
+            <Behavior RepaintControlsIDs="frmTimeline" CommitChanges="True" />
+        </AutoCallBack>
+        <ClientEvents AfterRowDblClick="sb501000OnGridDblClick" />
+    </px:PXGrid>
 
-                    <%-- Group 2: Booking & Docs --%>
-                    <px:PXLayoutRule ID="lrBooking" runat="server" StartColumn="True"
-                        StartGroup="True" GroupCaption="Booking &amp; Docs" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXTextEdit ID="edBookingRef" runat="server" DataField="BookingRef" />
-                    <px:PXTextEdit ID="edBillOfLading" runat="server" DataField="BillOfLading" />
-                    <px:PXTextEdit ID="edContainerType" runat="server" DataField="ContainerType" />
-                    <px:PXSelector ID="edFreightForwarderID" runat="server" DataField="FreightForwarderID" />
-                    <px:PXSelector ID="edBrokerID" runat="server" DataField="BrokerID" />
-                    <px:PXTextEdit ID="edLandedCostRefNbr" runat="server" DataField="LandedCostRefNbr" />
-                    <px:PXTextEdit ID="edLandedCostStatus" runat="server" DataField="LandedCostStatus" />
+    <%-- Slide-out detail panel (right-anchored) --%>
+    <px:PXSmartPanel ID="pnlContainerDetail" runat="server"
+        Caption="Container Detail" CaptionVisible="True"
+        LoadOnDemand="True" Key="Container" AutoCallBack-Enabled="True"
+        AutoCallBack-Target="frmDetail" AutoCallBack-ActiveBehavior="True"
+        ShowCloseButton="True" Width="600px" Height="100%">
 
-                    <%-- Group 3: Timeline & Ports --%>
-                    <px:PXLayoutRule ID="lrTimeline" runat="server" StartColumn="True"
-                        StartGroup="True" GroupCaption="Timeline &amp; Ports" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXDateTimeEdit ID="edETD" runat="server" DataField="ETD" />
-                    <px:PXDateTimeEdit ID="edETA" runat="server" DataField="ETA" CommitChanges="True" />
-                    <px:PXDateTimeEdit ID="edATA" runat="server" DataField="ATA" />
-                    <px:PXDateTimeEdit ID="edLastFreeDay" runat="server" DataField="LastFreeDay" />
-                    <px:PXNumberEdit ID="edDemurrageDailyRate" runat="server" DataField="DemurrageDailyRate" />
-                    <px:PXTextEdit ID="edPortOfLoading" runat="server" DataField="PortOfLoading" />
-                    <px:PXTextEdit ID="edPortOfDischarge" runat="server" DataField="PortOfDischarge" />
+        <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
+            Width="100%" CaptionVisible="False">
+            <Template>
+                <%-- Group 1: Identity --%>
+                <px:PXLayoutRule ID="lrIdentity" runat="server" StartColumn="True"
+                    StartGroup="True" GroupCaption="Identity" LabelsWidth="SM" ControlSize="M" />
+                <px:PXSelector ID="edContainerCD" runat="server" DataField="ContainerCD" Enabled="False" />
+                <px:PXDropDown ID="edStatus" runat="server" DataField="Status" CommitChanges="True" />
+                <px:PXTextEdit ID="edCarrierCode" runat="server" DataField="CarrierCode" />
+                <px:PXDropDown ID="edTransportMode" runat="server" DataField="TransportMode" />
+                <px:PXTextEdit ID="edVesselName" runat="server" DataField="VesselName" />
+                <px:PXTextEdit ID="edSealNbr" runat="server" DataField="SealNbr" />
 
-                    <%-- 2026-04-12: IIG parity — Shipping & Delivery dates --%>
-                    <px:PXLayoutRule ID="lrShipping" runat="server"
-                        StartGroup="True" GroupCaption="Shipping &amp; Delivery" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
-                    <px:PXDateTimeEdit ID="edFactoryPickupDate" runat="server" DataField="FactoryPickupDate" />
-                    <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />
-                    <px:PXDateTimeEdit ID="edShipmentWindowStart" runat="server" DataField="ShipmentWindowStart" />
-                    <px:PXDateTimeEdit ID="edShipmentWindowEnd" runat="server" DataField="ShipmentWindowEnd" />
-                    <px:PXDateTimeEdit ID="edDrayageAppointmentDate" runat="server" DataField="DrayageAppointmentDate" />
-                    <px:PXTextEdit ID="edDeliveryOrderNbr" runat="server" DataField="DeliveryOrderNbr" />
-                    <px:PXDateTimeEdit ID="edDeliveryOrderDate" runat="server" DataField="DeliveryOrderDate" />
-                    <px:PXDateTimeEdit ID="edPaymentDueDate" runat="server" DataField="PaymentDueDate" />
-                    <px:PXNumberEdit ID="edEstimatedFreight" runat="server" DataField="EstimatedFreight" />
-                    <px:PXTextEdit ID="edSCACNumber" runat="server" DataField="SCACNumber" />
-                    <px:PXTextEdit ID="edBrokerInvoiceNbr" runat="server" DataField="BrokerInvoiceNbr" />
-                </Template>
-            </px:PXFormView>
-            <px:PXTab ID="tabDetail" runat="server" Width="100%" DataSourceID="ds">
-                <Items>
-                    <px:PXTabItem Text="Events">
-                        <Template>
-                            <px:PXGrid ID="gridEvents" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <Levels>
-                                    <px:PXGridLevel DataMember="Events">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="EventDateTime" Width="130" />
-                                            <px:PXGridColumn DataField="NormalizedEventCode" Width="120" />
-                                            <px:PXGridColumn DataField="Description" Width="250" />
-                                            <px:PXGridColumn DataField="LocationName" Width="150" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <px:PXTabItem Text="PO Links">
-                        <Template>
-                            <px:PXGrid ID="gridPOLinks" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <%-- 2026-04-08: Phase E — wire Add/Remove PO Line actions to toolbar --%>
-                                <ActionBar>
-                                    <CustomItems>
-                                        <px:PXToolBarButton Text="Add PO Line" CommandName="AddPOLink" CommandSourceID="ds" />
-                                        <px:PXToolBarButton Text="Remove PO Line" CommandName="RemovePOLink" CommandSourceID="ds" />
-                                    </CustomItems>
-                                </ActionBar>
-                                <Levels>
-                                    <px:PXGridLevel DataMember="POLinks">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="OrderType" Width="60" />
-                                            <px:PXGridColumn DataField="OrderNbr" Width="90" />
-                                            <px:PXGridColumn DataField="BAccount__AcctName" Width="140" />
-                                            <px:PXGridColumn DataField="LineNbr" Width="50" />
-                                            <px:PXGridColumn DataField="InventoryItem__InventoryCD" Width="120" />
-                                            <px:PXGridColumn DataField="InventoryItem__Descr" Width="180" />
-                                            <px:PXGridColumn DataField="POLine__OrderQty" Width="80" />
-                                            <px:PXGridColumn DataField="POLine__UOM" Width="60" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <px:PXTabItem Text="Costs">
-                        <Template>
-                            <px:PXGrid ID="gridCosts" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <Levels>
-                                    <px:PXGridLevel DataMember="Costs">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="CostType" Width="100" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="Description" Width="180" />
-                                            <px:PXGridColumn DataField="Amount" Width="100" />
-                                            <px:PXGridColumn DataField="VendorID" Width="140" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="ReferenceNbr" Width="120" />
-                                            <px:PXGridColumn DataField="APDocType" Width="80" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="APRefNbr" Width="110" CommitChanges="True" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <%-- 2026-04-08: Phase E — Documents tab (per-container document checklist) --%>
-                    <px:PXTabItem Text="Documents">
-                        <Template>
-                            <px:PXGrid ID="gridDocuments" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <ActionBar>
-                                    <CustomItems>
-                                        <px:PXToolBarButton Text="Attach Document" CommandName="AttachDocument" CommandSourceID="ds" />
-                                    </CustomItems>
-                                </ActionBar>
-                                <Levels>
-                                    <px:PXGridLevel DataMember="Documents">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="DocumentType" Width="180" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="Required" Width="80" Type="CheckBox" />
-                                            <px:PXGridColumn DataField="Status" Width="100" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="ReceivedDate" Width="110" />
-                                            <px:PXGridColumn DataField="Note" Width="240" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <%-- 2026-04-08: Phase E — ETA History tab (forwarder-lie detection) --%>
-                    <px:PXTabItem Text="ETA History">
-                        <Template>
-                            <px:PXGrid ID="gridETAHistory" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <ActionBar>
-                                    <CustomItems>
-                                        <px:PXToolBarButton Text="Snapshot Current ETA" CommandName="RecordETAUpdate" CommandSourceID="ds" />
-                                    </CustomItems>
-                                </ActionBar>
-                                <Levels>
-                                    <px:PXGridLevel DataMember="ETAHistory">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="RecordedDate" Width="130" />
-                                            <px:PXGridColumn DataField="PreviousETA" Width="110" />
-                                            <px:PXGridColumn DataField="NewETA" Width="110" />
-                                            <px:PXGridColumn DataField="Source" Width="100" />
-                                            <px:PXGridColumn DataField="Note" Width="260" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <%-- 2026-04-11: PCC redesign — Lead Time breakdown per PO line --%>
-                    <px:PXTabItem Text="Lead Time">
-                        <Template>
-                            <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
-                                Width="100%" SkinID="Details">
-                                <Levels>
-                                    <px:PXGridLevel DataMember="LeadTimes">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="OrderNbr" Width="100" />
-                                            <px:PXGridColumn DataField="VendorName" Width="120" />
-                                            <px:PXGridColumn DataField="InventoryCD" Width="120" />
-                                            <px:PXGridColumn DataField="PlacedToAcked" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="AckedToFactory" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="FactoryToShip" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="ShipToDeliver" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="TotalDays" Width="60" TextAlign="Right" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                </Items>
-            </px:PXTab>
+                <%-- Group 2: Booking & Docs --%>
+                <px:PXLayoutRule ID="lrBooking" runat="server"
+                    StartGroup="True" GroupCaption="Booking &amp; Docs" LabelsWidth="SM" ControlSize="M" />
+                <px:PXTextEdit ID="edBookingRef" runat="server" DataField="BookingRef" />
+                <px:PXTextEdit ID="edBillOfLading" runat="server" DataField="BillOfLading" />
+                <px:PXTextEdit ID="edContainerType" runat="server" DataField="ContainerType" />
+                <px:PXSelector ID="edFreightForwarderID" runat="server" DataField="FreightForwarderID" />
+                <px:PXSelector ID="edBrokerID" runat="server" DataField="BrokerID" />
+                <px:PXTextEdit ID="edLandedCostRefNbr" runat="server" DataField="LandedCostRefNbr" />
+                <px:PXTextEdit ID="edLandedCostStatus" runat="server" DataField="LandedCostStatus" />
 
-            <%-- 2026-04-08: Phase E — Smart panel for Add PO Line action.
-                 Graph declares AddPOLineFilter as a PXFilter and exposes it via
-                 AddPOLink action which calls AskExt() on this panel. --%>
-            <px:PXSmartPanel ID="pnlAddPOLine" runat="server" Style="z-index: 100;"
-                Caption="Add PO Line to Container" CaptionVisible="True"
-                LoadOnDemand="True" Key="AddPOLineFilter" AutoCallBack-Enabled="True"
-                AutoCallBack-Target="frmAddPOLineFilter"
-                AutoCallBack-ActiveBehavior="True" AcceptButtonID="btnAddPOLineOK" Width="420px">
-                <px:PXFormView ID="frmAddPOLineFilter" runat="server" DataSourceID="ds"
-                    Style="z-index: 100" Width="100%" CaptionVisible="False"
-                    DataMember="AddPOLineFilter" SkinID="Transparent">
+                <%-- Group 3: Dates (consolidated) --%>
+                <px:PXLayoutRule ID="lrDates" runat="server"
+                    StartGroup="True" GroupCaption="Dates" LabelsWidth="SM" ControlSize="M" />
+                <px:PXDateTimeEdit ID="edETD" runat="server" DataField="ETD" />
+                <px:PXDateTimeEdit ID="edETA" runat="server" DataField="ETA" CommitChanges="True" />
+                <px:PXDateTimeEdit ID="edATA" runat="server" DataField="ATA" />
+                <px:PXDateTimeEdit ID="edLastFreeDay" runat="server" DataField="LastFreeDay" />
+                <px:PXNumberEdit ID="edDemurrageDailyRate" runat="server" DataField="DemurrageDailyRate" />
+                <px:PXDateTimeEdit ID="edMillAckDate" runat="server" DataField="MillAckDate" />
+                <px:PXDateTimeEdit ID="edFactoryPromisedDate" runat="server" DataField="FactoryPromisedDate" />
+                <px:PXDateTimeEdit ID="edFactoryActualDate" runat="server" DataField="FactoryActualDate" />
+                <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
+                <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />
+                <px:PXDateTimeEdit ID="edDrayageAppointmentDate" runat="server" DataField="DrayageAppointmentDate" />
+                <px:PXTextEdit ID="edDeliveryOrderNbr" runat="server" DataField="DeliveryOrderNbr" />
+                <px:PXDateTimeEdit ID="edDeliveryOrderDate" runat="server" DataField="DeliveryOrderDate" />
+                <px:PXDateTimeEdit ID="edPaymentDueDate" runat="server" DataField="PaymentDueDate" />
+                <px:PXNumberEdit ID="edEstimatedFreight" runat="server" DataField="EstimatedFreight" />
+                <px:PXTextEdit ID="edSCACNumber" runat="server" DataField="SCACNumber" />
+                <px:PXTextEdit ID="edBrokerInvoiceNbr" runat="server" DataField="BrokerInvoiceNbr" />
+            </Template>
+        </px:PXFormView>
+        <px:PXTab ID="tabDetail" runat="server" Width="100%" DataSourceID="ds">
+            <Items>
+                <px:PXTabItem Text="Events">
                     <Template>
-                        <px:PXLayoutRule ID="pnlLayoutRule1" runat="server" StartColumn="True" LabelsWidth="S" ControlSize="M" />
-                        <px:PXSelector ID="edPnlVendorID" runat="server" DataField="VendorID" CommitChanges="True" />
-                        <px:PXSelector ID="edPnlOrderNbr" runat="server" DataField="OrderNbr" CommitChanges="True" />
-                        <px:PXSelector ID="edPnlLineNbr" runat="server" DataField="LineNbr" CommitChanges="True" />
+                        <px:PXGrid ID="gridEvents" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <Levels>
+                                <px:PXGridLevel DataMember="Events">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="EventDateTime" Width="130" />
+                                        <px:PXGridColumn DataField="NormalizedEventCode" Width="120" />
+                                        <px:PXGridColumn DataField="Description" Width="250" />
+                                        <px:PXGridColumn DataField="LocationName" Width="150" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
                     </Template>
-                </px:PXFormView>
-                <div style="padding:8px; text-align:right;">
-                    <px:PXButton ID="btnAddPOLineOK" runat="server" DialogResult="OK" Text="Add" />
-                    <px:PXButton ID="btnAddPOLineCancel" runat="server" DialogResult="Cancel" Text="Cancel" />
-                </div>
-            </px:PXSmartPanel>
-        </Template2>
-    </px:PXSplitContainer>
+                </px:PXTabItem>
+                <px:PXTabItem Text="PO Links">
+                    <Template>
+                        <px:PXGrid ID="gridPOLinks" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <ActionBar>
+                                <CustomItems>
+                                    <px:PXToolBarButton Text="Add PO Line" CommandName="AddPOLink" CommandSourceID="ds" />
+                                    <px:PXToolBarButton Text="Remove PO Line" CommandName="RemovePOLink" CommandSourceID="ds" />
+                                </CustomItems>
+                            </ActionBar>
+                            <Levels>
+                                <px:PXGridLevel DataMember="POLinks">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="OrderType" Width="60" />
+                                        <px:PXGridColumn DataField="OrderNbr" Width="90" />
+                                        <px:PXGridColumn DataField="BAccount__AcctName" Width="140" />
+                                        <px:PXGridColumn DataField="LineNbr" Width="50" />
+                                        <px:PXGridColumn DataField="InventoryItem__InventoryCD" Width="120" />
+                                        <px:PXGridColumn DataField="InventoryItem__Descr" Width="180" />
+                                        <px:PXGridColumn DataField="POLine__OrderQty" Width="80" />
+                                        <px:PXGridColumn DataField="POLine__UOM" Width="60" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="Costs">
+                    <Template>
+                        <px:PXGrid ID="gridCosts" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <Levels>
+                                <px:PXGridLevel DataMember="Costs">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="CostType" Width="100" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="Description" Width="180" />
+                                        <px:PXGridColumn DataField="Amount" Width="100" />
+                                        <px:PXGridColumn DataField="VendorID" Width="140" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="ReferenceNbr" Width="120" />
+                                        <px:PXGridColumn DataField="APDocType" Width="80" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="APRefNbr" Width="110" CommitChanges="True" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="Documents">
+                    <Template>
+                        <px:PXGrid ID="gridDocuments" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <ActionBar>
+                                <CustomItems>
+                                    <px:PXToolBarButton Text="Attach Document" CommandName="AttachDocument" CommandSourceID="ds" />
+                                </CustomItems>
+                            </ActionBar>
+                            <Levels>
+                                <px:PXGridLevel DataMember="Documents">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="DocumentType" Width="180" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="Required" Width="80" Type="CheckBox" />
+                                        <px:PXGridColumn DataField="Status" Width="100" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="ReceivedDate" Width="110" />
+                                        <px:PXGridColumn DataField="Note" Width="240" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="ETA History">
+                    <Template>
+                        <px:PXGrid ID="gridETAHistory" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <ActionBar>
+                                <CustomItems>
+                                    <px:PXToolBarButton Text="Snapshot Current ETA" CommandName="RecordETAUpdate" CommandSourceID="ds" />
+                                </CustomItems>
+                            </ActionBar>
+                            <Levels>
+                                <px:PXGridLevel DataMember="ETAHistory">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="RecordedDate" Width="130" />
+                                        <px:PXGridColumn DataField="PreviousETA" Width="110" />
+                                        <px:PXGridColumn DataField="NewETA" Width="110" />
+                                        <px:PXGridColumn DataField="Source" Width="100" />
+                                        <px:PXGridColumn DataField="Note" Width="260" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="Lead Time">
+                    <Template>
+                        <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
+                            Width="100%" SkinID="Details">
+                            <Levels>
+                                <px:PXGridLevel DataMember="LeadTimes">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="OrderNbr" Width="100" />
+                                        <px:PXGridColumn DataField="VendorName" Width="120" />
+                                        <px:PXGridColumn DataField="InventoryCD" Width="120" />
+                                        <px:PXGridColumn DataField="PlacedToAcked" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="AckedToFactory" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="FactoryToShip" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="ShipToDeliver" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="TotalDays" Width="60" TextAlign="Right" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+            </Items>
+        </px:PXTab>
+    </px:PXSmartPanel>
+
+    <%-- Add PO Line smart panel --%>
+    <px:PXSmartPanel ID="pnlAddPOLine" runat="server" Style="z-index: 100;"
+        Caption="Add PO Line to Container" CaptionVisible="True"
+        LoadOnDemand="True" Key="AddPOLineFilter" AutoCallBack-Enabled="True"
+        AutoCallBack-Target="frmAddPOLineFilter"
+        AutoCallBack-ActiveBehavior="True" AcceptButtonID="btnAddPOLineOK" Width="420px">
+        <px:PXFormView ID="frmAddPOLineFilter" runat="server" DataSourceID="ds"
+            Style="z-index: 100" Width="100%" CaptionVisible="False"
+            DataMember="AddPOLineFilter" SkinID="Transparent">
+            <Template>
+                <px:PXLayoutRule ID="pnlLayoutRule1" runat="server" StartColumn="True" LabelsWidth="S" ControlSize="M" />
+                <px:PXSelector ID="edPnlVendorID" runat="server" DataField="VendorID" CommitChanges="True" />
+                <px:PXSelector ID="edPnlOrderNbr" runat="server" DataField="OrderNbr" CommitChanges="True" />
+                <px:PXSelector ID="edPnlLineNbr" runat="server" DataField="LineNbr" CommitChanges="True" />
+            </Template>
+        </px:PXFormView>
+        <div style="padding:8px; text-align:right;">
+            <px:PXButton ID="btnAddPOLineOK" runat="server" DialogResult="OK" Text="Add" />
+            <px:PXButton ID="btnAddPOLineCancel" runat="server" DialogResult="Cancel" Text="Cancel" />
+        </div>
+    </px:PXSmartPanel>
 </asp:Content>

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -296,7 +296,6 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
         <AutoCallBack Command="Refresh" Target="frmTimeline" ActiveBehavior="True">
             <Behavior RepaintControlsIDs="frmTimeline" CommitChanges="True" />
         </AutoCallBack>
-        <ClientEvents AfterRowDblClick="sb501000OnGridDblClick" />
     </px:PXGrid>
 
     <%-- Slide-out detail panel (right-anchored) --%>

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -236,16 +236,11 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
             <px:PXDSCallbackCommand Name="RecordETAUpdate" CommitChanges="True" Visible="False" />
             <px:PXDSCallbackCommand Name="PlanNextOrder" CommitChanges="True" StartNewGroup="True" />
             <px:PXDSCallbackCommand Name="ImportForwarderCSV" CommitChanges="True" StartNewGroup="True" />
+            <px:PXDSCallbackCommand Name="OpenContainerDetail" CommitChanges="True" Visible="False" />
         </CallbackCommands>
     </px:PXDataSource>
 </asp:Content>
 <asp:Content ID="cont2" ContentPlaceHolderID="phF" Runat="Server">
-    <%-- 2026-04-07: Command Center redesign — RFC 1 Phase B
-         Replaces the four edKPI* number-edit fields with a single PXHtmlView
-         bound to Filter.KPITilesHtml. The graph populates the HTML string in
-         RowSelected<ContainerFilter> via ContainerKPITileBuilder.
-         See docs/plans/2026-04-07-sb501000-kpi-tile-approved.md for the spec.
-    --%>
     <px:PXFormView ID="frmFilter" runat="server" DataSourceID="ds" DataMember="Filter"
         Width="100%" AllowAutoHide="false" CaptionVisible="False" RenderStyle="Simple"
         SkinID="Transparent">
@@ -253,289 +248,269 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
             <px:PXLayoutRule ID="PXLayoutRule1" runat="server" StartRow="True" />
             <px:PXHtmlView ID="htmlKPITiles" runat="server" DataField="KPITilesHtml"
                 Height="280px" Width="100%" SkinID="Label" />
-            <%-- Hidden field backing the tile click handlers. sb501000SetViewMode()
-                 in the embedded JS writes to this field, then postData() refreshes
-                 the grid with the new filter. --%>
             <px:PXDropDown ID="edViewMode" runat="server" DataField="ViewMode"
                 CommitChanges="True" Style="display:none;" />
         </Template>
     </px:PXFormView>
+    <%-- Timeline Command Bar — updates on grid row click --%>
+    <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Container"
+        Width="100%" CaptionVisible="False" RenderStyle="Simple" SkinID="Transparent">
+        <Template>
+            <px:PXLayoutRule runat="server" StartRow="True" />
+            <px:PXHtmlView ID="htmlTimeline" runat="server" DataField="TimelineHtml"
+                Height="90px" Width="100%" SkinID="Label" />
+            <px:PXTextEdit ID="edTabLabelsJson" runat="server" DataField="TabLabelsJson"
+                SuppressLabel="True" Style="display:none;" />
+        </Template>
+    </px:PXFormView>
 </asp:Content>
 <asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
-    <px:PXSplitContainer ID="splitMain" runat="server" Orientation="Vertical" SplitterPosition="400">
-        <AutoSize Enabled="True" Container="Window" />
-        <Template1>
-            <px:PXGrid ID="gridContainers" runat="server" DataSourceID="ds"
-                Width="100%" SkinID="Inquire" SyncPosition="True"
-                AllowPaging="True" AdjustPageSize="Auto" NoteIndicator="False" FilesIndicator="False">
-                <Levels>
-                    <px:PXGridLevel DataMember="Containers">
-                        <Columns>
-                            <%-- 2026-04-07: Phase C — Risk indicator + operational columns.
-                                 The Risk column is a one-letter code (R/A/G) that JS in
-                                 ContainerGridRowColorScript maps to row-level CSS classes. --%>
-                            <px:PXGridColumn DataField="RiskLevel" Width="30" TextAlign="Center" />
-                            <px:PXGridColumn DataField="ContainerCD" Width="120" />
-                            <px:PXGridColumn DataField="Status" Width="110" />
-                            <px:PXGridColumn DataField="TransportMode" Width="70" />
-                            <px:PXGridColumn DataField="CarrierCode" Width="80" />
-                            <px:PXGridColumn DataField="VesselName" Width="120" />
-                            <px:PXGridColumn DataField="ETA" Width="90" />
-                            <px:PXGridColumn DataField="ATA" Width="90" />
-                            <px:PXGridColumn DataField="LastFreeDay" Width="90" />
-                            <px:PXGridColumn DataField="DaysToLFD" Width="60" TextAlign="Right" />
-                            <px:PXGridColumn DataField="DocsSummary" Width="60" TextAlign="Center" />
-                            <px:PXGridColumn DataField="DemurrageExposure" Width="100" TextAlign="Right" />
-                            <px:PXGridColumn DataField="PortOfDischarge" Width="90" />
-                            <px:PXGridColumn DataField="LastEventCode" Width="100" />
-                        </Columns>
-                    </px:PXGridLevel>
-                </Levels>
-                <AutoSize Enabled="True" MinHeight="200" />
-                <AutoCallBack Command="Refresh" Target="frmDetail" ActiveBehavior="True">
-                    <Behavior RepaintControlsIDs="frmTimeline,frmDetail,tabDetail" CommitChanges="True" />
-                </AutoCallBack>
-            </px:PXGrid>
-        </Template1>
-        <Template2>
-            <%-- 2026-04-08: Phase D — Status timeline strip + grouped detail form.
-                 Timeline rendered via PXHtmlView bound to UsrContainer.TimelineHtml,
-                 populated in ContainerMaint.RowSelected<UsrContainer>. --%>
-            <px:PXFormView ID="frmTimeline" runat="server" DataSourceID="ds" DataMember="Container"
-                Width="100%" CaptionVisible="False" RenderStyle="Simple" SkinID="Transparent">
-                <Template>
-                    <%-- 2026-04-08: explicit layout rule so the hidden edTabLabelsJson
-                         below doesn't render a "Tab Labels:" label cell. Without this,
-                         PXFormView auto-layout wraps the field in a label-column +
-                         value-column row and Style="display:none;" only hits the
-                         inner input, leaving the label visible. Pattern mirrors
-                         frmFilter which correctly hides edViewMode the same way. --%>
-                    <px:PXLayoutRule runat="server" StartRow="True" />
-                    <px:PXHtmlView ID="htmlTimeline" runat="server" DataField="TimelineHtml"
-                        Height="90px" Width="100%" SkinID="Label" />
-                    <%-- Hidden field carrying tab label JSON for the JS updater --%>
-                    <px:PXTextEdit ID="edTabLabelsJson" runat="server" DataField="TabLabelsJson"
-                        SuppressLabel="True" Style="display:none;" />
-                </Template>
-            </px:PXFormView>
-            <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
-                Width="100%" CaptionVisible="False">
-                <Template>
-                    <%-- Group 1: Identity --%>
-                    <px:PXLayoutRule ID="lrIdentity" runat="server" StartColumn="True"
-                        StartGroup="True" GroupCaption="Identity" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXSelector ID="edContainerCD" runat="server" DataField="ContainerCD" Enabled="False" />
-                    <px:PXDropDown ID="edStatus" runat="server" DataField="Status" CommitChanges="True" />
-                    <px:PXTextEdit ID="edCarrierCode" runat="server" DataField="CarrierCode" />
-                    <px:PXDropDown ID="edTransportMode" runat="server" DataField="TransportMode" />
-                    <px:PXTextEdit ID="edVesselName" runat="server" DataField="VesselName" />
-                    <px:PXTextEdit ID="edSealNbr" runat="server" DataField="SealNbr" />
+    <%-- Full-width container grid --%>
+    <px:PXGrid ID="gridContainers" runat="server" DataSourceID="ds"
+        Width="100%" SkinID="Inquire" SyncPosition="True"
+        AllowPaging="True" AdjustPageSize="Auto" NoteIndicator="False" FilesIndicator="False">
+        <Levels>
+            <px:PXGridLevel DataMember="Containers">
+                <Columns>
+                    <px:PXGridColumn DataField="RiskLevel" Width="30" TextAlign="Center" />
+                    <px:PXGridColumn DataField="ContainerCD" Width="120" LinkCommand="OpenContainerDetail" />
+                    <px:PXGridColumn DataField="Status" Width="110" />
+                    <px:PXGridColumn DataField="TransportMode" Width="70" />
+                    <px:PXGridColumn DataField="CarrierCode" Width="80" />
+                    <px:PXGridColumn DataField="VesselName" Width="120" />
+                    <px:PXGridColumn DataField="ETA" Width="90" />
+                    <px:PXGridColumn DataField="ATA" Width="90" />
+                    <px:PXGridColumn DataField="LastFreeDay" Width="90" />
+                    <px:PXGridColumn DataField="DaysToLFD" Width="60" TextAlign="Right" />
+                    <px:PXGridColumn DataField="DemurrageExposure" Width="100" TextAlign="Right" />
+                    <px:PXGridColumn DataField="FactoryPromisedDate" Width="90" />
+                    <px:PXGridColumn DataField="FactoryActualDate" Width="90" />
+                    <px:PXGridColumn DataField="MillAckDate" Width="90" />
+                    <px:PXGridColumn DataField="DocsSummary" Width="60" TextAlign="Center" />
+                    <px:PXGridColumn DataField="PortOfDischarge" Width="90" />
+                    <px:PXGridColumn DataField="LastEventCode" Width="100" />
+                </Columns>
+            </px:PXGridLevel>
+        </Levels>
+        <AutoSize Enabled="True" MinHeight="300" Container="Window" />
+        <AutoCallBack Command="Refresh" Target="frmTimeline" ActiveBehavior="True">
+            <Behavior RepaintControlsIDs="frmTimeline" CommitChanges="True" />
+        </AutoCallBack>
+        <ClientEvents AfterRowDblClick="sb501000OnGridDblClick" />
+    </px:PXGrid>
 
-                    <%-- Group 2: Booking & Docs --%>
-                    <px:PXLayoutRule ID="lrBooking" runat="server" StartColumn="True"
-                        StartGroup="True" GroupCaption="Booking &amp; Docs" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXTextEdit ID="edBookingRef" runat="server" DataField="BookingRef" />
-                    <px:PXTextEdit ID="edBillOfLading" runat="server" DataField="BillOfLading" />
-                    <px:PXTextEdit ID="edContainerType" runat="server" DataField="ContainerType" />
-                    <px:PXSelector ID="edFreightForwarderID" runat="server" DataField="FreightForwarderID" />
-                    <px:PXSelector ID="edBrokerID" runat="server" DataField="BrokerID" />
-                    <px:PXTextEdit ID="edLandedCostRefNbr" runat="server" DataField="LandedCostRefNbr" />
-                    <px:PXTextEdit ID="edLandedCostStatus" runat="server" DataField="LandedCostStatus" />
+    <%-- Slide-out detail panel (right-anchored) --%>
+    <px:PXSmartPanel ID="pnlContainerDetail" runat="server"
+        Caption="Container Detail" CaptionVisible="True"
+        LoadOnDemand="True" Key="Container" AutoCallBack-Enabled="True"
+        AutoCallBack-Target="frmDetail" AutoCallBack-ActiveBehavior="True"
+        ShowCloseButton="True" Width="600px" Height="100%">
 
-                    <%-- Group 3: Timeline & Ports --%>
-                    <px:PXLayoutRule ID="lrTimeline" runat="server" StartColumn="True"
-                        StartGroup="True" GroupCaption="Timeline &amp; Ports" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXDateTimeEdit ID="edETD" runat="server" DataField="ETD" />
-                    <px:PXDateTimeEdit ID="edETA" runat="server" DataField="ETA" CommitChanges="True" />
-                    <px:PXDateTimeEdit ID="edATA" runat="server" DataField="ATA" />
-                    <px:PXDateTimeEdit ID="edLastFreeDay" runat="server" DataField="LastFreeDay" />
-                    <px:PXNumberEdit ID="edDemurrageDailyRate" runat="server" DataField="DemurrageDailyRate" />
-                    <px:PXTextEdit ID="edPortOfLoading" runat="server" DataField="PortOfLoading" />
-                    <px:PXTextEdit ID="edPortOfDischarge" runat="server" DataField="PortOfDischarge" />
+        <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
+            Width="100%" CaptionVisible="False">
+            <Template>
+                <%-- Group 1: Identity --%>
+                <px:PXLayoutRule ID="lrIdentity" runat="server" StartColumn="True"
+                    StartGroup="True" GroupCaption="Identity" LabelsWidth="SM" ControlSize="M" />
+                <px:PXSelector ID="edContainerCD" runat="server" DataField="ContainerCD" Enabled="False" />
+                <px:PXDropDown ID="edStatus" runat="server" DataField="Status" CommitChanges="True" />
+                <px:PXTextEdit ID="edCarrierCode" runat="server" DataField="CarrierCode" />
+                <px:PXDropDown ID="edTransportMode" runat="server" DataField="TransportMode" />
+                <px:PXTextEdit ID="edVesselName" runat="server" DataField="VesselName" />
+                <px:PXTextEdit ID="edSealNbr" runat="server" DataField="SealNbr" />
 
-                    <%-- 2026-04-12: IIG parity — Shipping & Delivery dates --%>
-                    <px:PXLayoutRule ID="lrShipping" runat="server"
-                        StartGroup="True" GroupCaption="Shipping &amp; Delivery" LabelsWidth="SM" ControlSize="M" />
-                    <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
-                    <px:PXDateTimeEdit ID="edFactoryPickupDate" runat="server" DataField="FactoryPickupDate" />
-                    <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />
-                    <px:PXDateTimeEdit ID="edShipmentWindowStart" runat="server" DataField="ShipmentWindowStart" />
-                    <px:PXDateTimeEdit ID="edShipmentWindowEnd" runat="server" DataField="ShipmentWindowEnd" />
-                    <px:PXDateTimeEdit ID="edDrayageAppointmentDate" runat="server" DataField="DrayageAppointmentDate" />
-                    <px:PXTextEdit ID="edDeliveryOrderNbr" runat="server" DataField="DeliveryOrderNbr" />
-                    <px:PXDateTimeEdit ID="edDeliveryOrderDate" runat="server" DataField="DeliveryOrderDate" />
-                    <px:PXDateTimeEdit ID="edPaymentDueDate" runat="server" DataField="PaymentDueDate" />
-                    <px:PXNumberEdit ID="edEstimatedFreight" runat="server" DataField="EstimatedFreight" />
-                    <px:PXTextEdit ID="edSCACNumber" runat="server" DataField="SCACNumber" />
-                    <px:PXTextEdit ID="edBrokerInvoiceNbr" runat="server" DataField="BrokerInvoiceNbr" />
-                </Template>
-            </px:PXFormView>
-            <px:PXTab ID="tabDetail" runat="server" Width="100%" DataSourceID="ds">
-                <Items>
-                    <px:PXTabItem Text="Events">
-                        <Template>
-                            <px:PXGrid ID="gridEvents" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <Levels>
-                                    <px:PXGridLevel DataMember="Events">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="EventDateTime" Width="130" />
-                                            <px:PXGridColumn DataField="NormalizedEventCode" Width="120" />
-                                            <px:PXGridColumn DataField="Description" Width="250" />
-                                            <px:PXGridColumn DataField="LocationName" Width="150" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <px:PXTabItem Text="PO Links">
-                        <Template>
-                            <px:PXGrid ID="gridPOLinks" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <%-- 2026-04-08: Phase E — wire Add/Remove PO Line actions to toolbar --%>
-                                <ActionBar>
-                                    <CustomItems>
-                                        <px:PXToolBarButton Text="Add PO Line" CommandName="AddPOLink" CommandSourceID="ds" />
-                                        <px:PXToolBarButton Text="Remove PO Line" CommandName="RemovePOLink" CommandSourceID="ds" />
-                                    </CustomItems>
-                                </ActionBar>
-                                <Levels>
-                                    <px:PXGridLevel DataMember="POLinks">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="OrderType" Width="60" />
-                                            <px:PXGridColumn DataField="OrderNbr" Width="90" />
-                                            <px:PXGridColumn DataField="BAccount__AcctName" Width="140" />
-                                            <px:PXGridColumn DataField="LineNbr" Width="50" />
-                                            <px:PXGridColumn DataField="InventoryItem__InventoryCD" Width="120" />
-                                            <px:PXGridColumn DataField="InventoryItem__Descr" Width="180" />
-                                            <px:PXGridColumn DataField="POLine__OrderQty" Width="80" />
-                                            <px:PXGridColumn DataField="POLine__UOM" Width="60" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <px:PXTabItem Text="Costs">
-                        <Template>
-                            <px:PXGrid ID="gridCosts" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <Levels>
-                                    <px:PXGridLevel DataMember="Costs">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="CostType" Width="100" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="Description" Width="180" />
-                                            <px:PXGridColumn DataField="Amount" Width="100" />
-                                            <px:PXGridColumn DataField="VendorID" Width="140" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="ReferenceNbr" Width="120" />
-                                            <px:PXGridColumn DataField="APDocType" Width="80" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="APRefNbr" Width="110" CommitChanges="True" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <%-- 2026-04-08: Phase E — Documents tab (per-container document checklist) --%>
-                    <px:PXTabItem Text="Documents">
-                        <Template>
-                            <px:PXGrid ID="gridDocuments" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <ActionBar>
-                                    <CustomItems>
-                                        <px:PXToolBarButton Text="Attach Document" CommandName="AttachDocument" CommandSourceID="ds" />
-                                    </CustomItems>
-                                </ActionBar>
-                                <Levels>
-                                    <px:PXGridLevel DataMember="Documents">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="DocumentType" Width="180" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="Required" Width="80" Type="CheckBox" />
-                                            <px:PXGridColumn DataField="Status" Width="100" CommitChanges="True" />
-                                            <px:PXGridColumn DataField="ReceivedDate" Width="110" />
-                                            <px:PXGridColumn DataField="Note" Width="240" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <%-- 2026-04-08: Phase E — ETA History tab (forwarder-lie detection) --%>
-                    <px:PXTabItem Text="ETA History">
-                        <Template>
-                            <px:PXGrid ID="gridETAHistory" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
-                                <ActionBar>
-                                    <CustomItems>
-                                        <px:PXToolBarButton Text="Snapshot Current ETA" CommandName="RecordETAUpdate" CommandSourceID="ds" />
-                                    </CustomItems>
-                                </ActionBar>
-                                <Levels>
-                                    <px:PXGridLevel DataMember="ETAHistory">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="RecordedDate" Width="130" />
-                                            <px:PXGridColumn DataField="PreviousETA" Width="110" />
-                                            <px:PXGridColumn DataField="NewETA" Width="110" />
-                                            <px:PXGridColumn DataField="Source" Width="100" />
-                                            <px:PXGridColumn DataField="Note" Width="260" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                    <%-- 2026-04-11: PCC redesign — Lead Time breakdown per PO line --%>
-                    <px:PXTabItem Text="Lead Time">
-                        <Template>
-                            <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
-                                Width="100%" SkinID="Details">
-                                <Levels>
-                                    <px:PXGridLevel DataMember="LeadTimes">
-                                        <Columns>
-                                            <px:PXGridColumn DataField="OrderNbr" Width="100" />
-                                            <px:PXGridColumn DataField="VendorName" Width="120" />
-                                            <px:PXGridColumn DataField="InventoryCD" Width="120" />
-                                            <px:PXGridColumn DataField="PlacedToAcked" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="AckedToFactory" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="FactoryToShip" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="ShipToDeliver" Width="80" TextAlign="Right" />
-                                            <px:PXGridColumn DataField="TotalDays" Width="60" TextAlign="Right" />
-                                        </Columns>
-                                    </px:PXGridLevel>
-                                </Levels>
-                                <AutoSize Enabled="True" MinHeight="150" />
-                            </px:PXGrid>
-                        </Template>
-                    </px:PXTabItem>
-                </Items>
-            </px:PXTab>
+                <%-- Group 2: Booking & Docs --%>
+                <px:PXLayoutRule ID="lrBooking" runat="server"
+                    StartGroup="True" GroupCaption="Booking &amp; Docs" LabelsWidth="SM" ControlSize="M" />
+                <px:PXTextEdit ID="edBookingRef" runat="server" DataField="BookingRef" />
+                <px:PXTextEdit ID="edBillOfLading" runat="server" DataField="BillOfLading" />
+                <px:PXTextEdit ID="edContainerType" runat="server" DataField="ContainerType" />
+                <px:PXSelector ID="edFreightForwarderID" runat="server" DataField="FreightForwarderID" />
+                <px:PXSelector ID="edBrokerID" runat="server" DataField="BrokerID" />
+                <px:PXTextEdit ID="edLandedCostRefNbr" runat="server" DataField="LandedCostRefNbr" />
+                <px:PXTextEdit ID="edLandedCostStatus" runat="server" DataField="LandedCostStatus" />
 
-            <%-- 2026-04-08: Phase E — Smart panel for Add PO Line action.
-                 Graph declares AddPOLineFilter as a PXFilter and exposes it via
-                 AddPOLink action which calls AskExt() on this panel. --%>
-            <px:PXSmartPanel ID="pnlAddPOLine" runat="server" Style="z-index: 100;"
-                Caption="Add PO Line to Container" CaptionVisible="True"
-                LoadOnDemand="True" Key="AddPOLineFilter" AutoCallBack-Enabled="True"
-                AutoCallBack-Target="frmAddPOLineFilter"
-                AutoCallBack-ActiveBehavior="True" AcceptButtonID="btnAddPOLineOK" Width="420px">
-                <px:PXFormView ID="frmAddPOLineFilter" runat="server" DataSourceID="ds"
-                    Style="z-index: 100" Width="100%" CaptionVisible="False"
-                    DataMember="AddPOLineFilter" SkinID="Transparent">
+                <%-- Group 3: Dates (consolidated) --%>
+                <px:PXLayoutRule ID="lrDates" runat="server"
+                    StartGroup="True" GroupCaption="Dates" LabelsWidth="SM" ControlSize="M" />
+                <px:PXDateTimeEdit ID="edETD" runat="server" DataField="ETD" />
+                <px:PXDateTimeEdit ID="edETA" runat="server" DataField="ETA" CommitChanges="True" />
+                <px:PXDateTimeEdit ID="edATA" runat="server" DataField="ATA" />
+                <px:PXDateTimeEdit ID="edLastFreeDay" runat="server" DataField="LastFreeDay" />
+                <px:PXNumberEdit ID="edDemurrageDailyRate" runat="server" DataField="DemurrageDailyRate" />
+                <px:PXDateTimeEdit ID="edMillAckDate" runat="server" DataField="MillAckDate" />
+                <px:PXDateTimeEdit ID="edFactoryPromisedDate" runat="server" DataField="FactoryPromisedDate" />
+                <px:PXDateTimeEdit ID="edFactoryActualDate" runat="server" DataField="FactoryActualDate" />
+                <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
+                <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />
+                <px:PXDateTimeEdit ID="edDrayageAppointmentDate" runat="server" DataField="DrayageAppointmentDate" />
+                <px:PXTextEdit ID="edDeliveryOrderNbr" runat="server" DataField="DeliveryOrderNbr" />
+                <px:PXDateTimeEdit ID="edDeliveryOrderDate" runat="server" DataField="DeliveryOrderDate" />
+                <px:PXDateTimeEdit ID="edPaymentDueDate" runat="server" DataField="PaymentDueDate" />
+                <px:PXNumberEdit ID="edEstimatedFreight" runat="server" DataField="EstimatedFreight" />
+                <px:PXTextEdit ID="edSCACNumber" runat="server" DataField="SCACNumber" />
+                <px:PXTextEdit ID="edBrokerInvoiceNbr" runat="server" DataField="BrokerInvoiceNbr" />
+            </Template>
+        </px:PXFormView>
+        <px:PXTab ID="tabDetail" runat="server" Width="100%" DataSourceID="ds">
+            <Items>
+                <px:PXTabItem Text="Events">
                     <Template>
-                        <px:PXLayoutRule ID="pnlLayoutRule1" runat="server" StartColumn="True" LabelsWidth="S" ControlSize="M" />
-                        <px:PXSelector ID="edPnlVendorID" runat="server" DataField="VendorID" CommitChanges="True" />
-                        <px:PXSelector ID="edPnlOrderNbr" runat="server" DataField="OrderNbr" CommitChanges="True" />
-                        <px:PXSelector ID="edPnlLineNbr" runat="server" DataField="LineNbr" CommitChanges="True" />
+                        <px:PXGrid ID="gridEvents" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <Levels>
+                                <px:PXGridLevel DataMember="Events">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="EventDateTime" Width="130" />
+                                        <px:PXGridColumn DataField="NormalizedEventCode" Width="120" />
+                                        <px:PXGridColumn DataField="Description" Width="250" />
+                                        <px:PXGridColumn DataField="LocationName" Width="150" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
                     </Template>
-                </px:PXFormView>
-                <div style="padding:8px; text-align:right;">
-                    <px:PXButton ID="btnAddPOLineOK" runat="server" DialogResult="OK" Text="Add" />
-                    <px:PXButton ID="btnAddPOLineCancel" runat="server" DialogResult="Cancel" Text="Cancel" />
-                </div>
-            </px:PXSmartPanel>
-        </Template2>
-    </px:PXSplitContainer>
+                </px:PXTabItem>
+                <px:PXTabItem Text="PO Links">
+                    <Template>
+                        <px:PXGrid ID="gridPOLinks" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <ActionBar>
+                                <CustomItems>
+                                    <px:PXToolBarButton Text="Add PO Line" CommandName="AddPOLink" CommandSourceID="ds" />
+                                    <px:PXToolBarButton Text="Remove PO Line" CommandName="RemovePOLink" CommandSourceID="ds" />
+                                </CustomItems>
+                            </ActionBar>
+                            <Levels>
+                                <px:PXGridLevel DataMember="POLinks">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="OrderType" Width="60" />
+                                        <px:PXGridColumn DataField="OrderNbr" Width="90" />
+                                        <px:PXGridColumn DataField="BAccount__AcctName" Width="140" />
+                                        <px:PXGridColumn DataField="LineNbr" Width="50" />
+                                        <px:PXGridColumn DataField="InventoryItem__InventoryCD" Width="120" />
+                                        <px:PXGridColumn DataField="InventoryItem__Descr" Width="180" />
+                                        <px:PXGridColumn DataField="POLine__OrderQty" Width="80" />
+                                        <px:PXGridColumn DataField="POLine__UOM" Width="60" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="Costs">
+                    <Template>
+                        <px:PXGrid ID="gridCosts" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <Levels>
+                                <px:PXGridLevel DataMember="Costs">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="CostType" Width="100" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="Description" Width="180" />
+                                        <px:PXGridColumn DataField="Amount" Width="100" />
+                                        <px:PXGridColumn DataField="VendorID" Width="140" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="ReferenceNbr" Width="120" />
+                                        <px:PXGridColumn DataField="APDocType" Width="80" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="APRefNbr" Width="110" CommitChanges="True" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="Documents">
+                    <Template>
+                        <px:PXGrid ID="gridDocuments" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <ActionBar>
+                                <CustomItems>
+                                    <px:PXToolBarButton Text="Attach Document" CommandName="AttachDocument" CommandSourceID="ds" />
+                                </CustomItems>
+                            </ActionBar>
+                            <Levels>
+                                <px:PXGridLevel DataMember="Documents">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="DocumentType" Width="180" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="Required" Width="80" Type="CheckBox" />
+                                        <px:PXGridColumn DataField="Status" Width="100" CommitChanges="True" />
+                                        <px:PXGridColumn DataField="ReceivedDate" Width="110" />
+                                        <px:PXGridColumn DataField="Note" Width="240" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="ETA History">
+                    <Template>
+                        <px:PXGrid ID="gridETAHistory" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
+                            <ActionBar>
+                                <CustomItems>
+                                    <px:PXToolBarButton Text="Snapshot Current ETA" CommandName="RecordETAUpdate" CommandSourceID="ds" />
+                                </CustomItems>
+                            </ActionBar>
+                            <Levels>
+                                <px:PXGridLevel DataMember="ETAHistory">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="RecordedDate" Width="130" />
+                                        <px:PXGridColumn DataField="PreviousETA" Width="110" />
+                                        <px:PXGridColumn DataField="NewETA" Width="110" />
+                                        <px:PXGridColumn DataField="Source" Width="100" />
+                                        <px:PXGridColumn DataField="Note" Width="260" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+                <px:PXTabItem Text="Lead Time">
+                    <Template>
+                        <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
+                            Width="100%" SkinID="Details">
+                            <Levels>
+                                <px:PXGridLevel DataMember="LeadTimes">
+                                    <Columns>
+                                        <px:PXGridColumn DataField="OrderNbr" Width="100" />
+                                        <px:PXGridColumn DataField="VendorName" Width="120" />
+                                        <px:PXGridColumn DataField="InventoryCD" Width="120" />
+                                        <px:PXGridColumn DataField="PlacedToAcked" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="AckedToFactory" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="FactoryToShip" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="ShipToDeliver" Width="80" TextAlign="Right" />
+                                        <px:PXGridColumn DataField="TotalDays" Width="60" TextAlign="Right" />
+                                    </Columns>
+                                </px:PXGridLevel>
+                            </Levels>
+                            <AutoSize Enabled="True" MinHeight="150" />
+                        </px:PXGrid>
+                    </Template>
+                </px:PXTabItem>
+            </Items>
+        </px:PXTab>
+    </px:PXSmartPanel>
+
+    <%-- Add PO Line smart panel --%>
+    <px:PXSmartPanel ID="pnlAddPOLine" runat="server" Style="z-index: 100;"
+        Caption="Add PO Line to Container" CaptionVisible="True"
+        LoadOnDemand="True" Key="AddPOLineFilter" AutoCallBack-Enabled="True"
+        AutoCallBack-Target="frmAddPOLineFilter"
+        AutoCallBack-ActiveBehavior="True" AcceptButtonID="btnAddPOLineOK" Width="420px">
+        <px:PXFormView ID="frmAddPOLineFilter" runat="server" DataSourceID="ds"
+            Style="z-index: 100" Width="100%" CaptionVisible="False"
+            DataMember="AddPOLineFilter" SkinID="Transparent">
+            <Template>
+                <px:PXLayoutRule ID="pnlLayoutRule1" runat="server" StartColumn="True" LabelsWidth="S" ControlSize="M" />
+                <px:PXSelector ID="edPnlVendorID" runat="server" DataField="VendorID" CommitChanges="True" />
+                <px:PXSelector ID="edPnlOrderNbr" runat="server" DataField="OrderNbr" CommitChanges="True" />
+                <px:PXSelector ID="edPnlLineNbr" runat="server" DataField="LineNbr" CommitChanges="True" />
+            </Template>
+        </px:PXFormView>
+        <div style="padding:8px; text-align:right;">
+            <px:PXButton ID="btnAddPOLineOK" runat="server" DialogResult="OK" Text="Add" />
+            <px:PXButton ID="btnAddPOLineCancel" runat="server" DialogResult="Cancel" Text="Cancel" />
+        </div>
+    </px:PXSmartPanel>
 </asp:Content>
 ]]></CDATA>
     </File>

--- a/src/StudioB.Containers/DACs/ContainerFilter.cs
+++ b/src/StudioB.Containers/DACs/ContainerFilter.cs
@@ -37,49 +37,20 @@ namespace StudioB.Containers
         public string ViewMode { get; set; }
         #endregion
 
-        // Tile 1 — ACTION REQUIRED
-        #region KPIActionCount
-        public abstract class kpiActionCount : BqlInt.Field<kpiActionCount> { }
+        // Tile 1 — LATE
+        #region KPILateCount
+        public abstract class kpiLateCount : BqlInt.Field<kpiLateCount> { }
         [PXInt]
-        [PXUIField(DisplayName = "Action Required", Enabled = false)]
-        public int? KPIActionCount { get; set; }
+        [PXUIField(DisplayName = "Late", Enabled = false)]
+        public int? KPILateCount { get; set; }
         #endregion
 
-        #region KPIActionBreakdown
-        public abstract class kpiActionBreakdown : BqlString.Field<kpiActionBreakdown> { }
-        [PXString(500)]
-        [PXUIField(DisplayName = "Action Breakdown", Enabled = false)]
-        public string KPIActionBreakdown { get; set; }
-        #endregion
-
-        // Tile 2 — WATCH
-        #region KPIWatchCount
-        public abstract class kpiWatchCount : BqlInt.Field<kpiWatchCount> { }
-        [PXInt]
-        [PXUIField(DisplayName = "Watch", Enabled = false)]
-        public int? KPIWatchCount { get; set; }
-        #endregion
-
-        #region KPIWatchBreakdown
-        public abstract class kpiWatchBreakdown : BqlString.Field<kpiWatchBreakdown> { }
-        [PXString(500)]
-        [PXUIField(DisplayName = "Watch Breakdown", Enabled = false)]
-        public string KPIWatchBreakdown { get; set; }
-        #endregion
-
-        // Tile 3 — $ EXPOSURE
-        #region KPIExposureTotal
-        public abstract class kpiExposureTotal : BqlDecimal.Field<kpiExposureTotal> { }
+        // Tile 2 — AT RISK $
+        #region KPIAtRiskTotal
+        public abstract class kpiAtRiskTotal : BqlDecimal.Field<kpiAtRiskTotal> { }
         [PXDecimal(2)]
-        [PXUIField(DisplayName = "Exposure", Enabled = false)]
-        public decimal? KPIExposureTotal { get; set; }
-        #endregion
-
-        #region KPIExposureBreakdown
-        public abstract class kpiExposureBreakdown : BqlString.Field<kpiExposureBreakdown> { }
-        [PXString(500)]
-        [PXUIField(DisplayName = "Exposure Breakdown", Enabled = false)]
-        public string KPIExposureBreakdown { get; set; }
+        [PXUIField(DisplayName = "At Risk", Enabled = false)]
+        public decimal? KPIAtRiskTotal { get; set; }
         #endregion
 
         // Rendered HTML for PXHtmlView tile row

--- a/src/StudioB.Containers/DACs/UsrContainer.cs
+++ b/src/StudioB.Containers/DACs/UsrContainer.cs
@@ -525,6 +525,29 @@ namespace StudioB.Containers
         #endregion
         // --- end 2026-04-12 additions ---
 
+        // --- 2026-04-11: PCC redesign — Mill date fields ---
+        #region MillAckDate
+        public abstract class millAckDate : BqlDateTime.Field<millAckDate> { }
+        [PXDBDate(PreserveTime = true)]
+        [PXUIField(DisplayName = "Mill Ack Date")]
+        public DateTime? MillAckDate { get; set; }
+        #endregion
+
+        #region FactoryPromisedDate
+        public abstract class factoryPromisedDate : BqlDateTime.Field<factoryPromisedDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Factory Promised")]
+        public DateTime? FactoryPromisedDate { get; set; }
+        #endregion
+
+        #region FactoryActualDate
+        public abstract class factoryActualDate : BqlDateTime.Field<factoryActualDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Factory Actual")]
+        public DateTime? FactoryActualDate { get; set; }
+        #endregion
+        // --- end 2026-04-11 mill date fields ---
+
         #region NoteID
         public abstract class noteID : BqlGuid.Field<noteID> { }
         [PXNote]

--- a/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
+++ b/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
@@ -99,6 +99,10 @@ namespace StudioB.Containers
                     EnsureColumn(conn, "UsrContainer", "BrokerInvoiceNbr",       "nvarchar(30) NULL");
                     EnsureColumn(conn, "UsrContainer", "SCACNumber",             "nvarchar(10) NULL");
                     EnsureColumn(conn, "UsrContainer", "EstimatedFreight",       "decimal(19,4) NULL");
+                    // 2026-04-11: PCC redesign — mill date fields
+                    EnsureColumn(conn, "UsrContainer", "MillAckDate",          "datetime NULL");
+                    EnsureColumn(conn, "UsrContainer", "FactoryPromisedDate",  "datetime NULL");
+                    EnsureColumn(conn, "UsrContainer", "FactoryActualDate",    "datetime NULL");
 
                     EnsureTable(conn, "UsrContainerEvent", @"
                         CompanyID int NOT NULL DEFAULT 0,

--- a/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
@@ -328,14 +328,6 @@ window.sb501000SetViewMode = function(mode) {
     }
   } catch(e) { console.error('sb501000SetViewMode failed', e); }
 };
-window.sb501000OnGridDblClick = function(sender, args) {
-  try {
-    var ds = px_alls['ds'];
-    if (ds && ds.executeCallback) {
-      ds.executeCallback('OpenContainerDetail');
-    }
-  } catch(e) { console.error('sb501000OnGridDblClick failed', e); }
-};
 /* --- Phase D: update tabDetail tab labels from TabLabelsJson hidden field --- */
 window.sb501000ApplyTabLabels = function() {
   try {

--- a/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
@@ -13,19 +13,23 @@ namespace StudioB.Containers
     {
         public struct KPIData
         {
-            public int ActionCount;
-            public int WatchCount;
-            public decimal ExposureTotal;
-            public int ActionPastLFD;
-            public decimal ActionPastLFDDailyRate;
-            public int ActionCustomsHold;
-            public int ActionISFCutoff;
-            public int WatchEtaSlipped;
-            public int WatchDocsIncomplete;
-            public int WatchArrivingSoon;
-            public decimal ExposureDemurrage;
-            public decimal ExposureDutyVariance;
-            public decimal ExposureOther;
+            // Tile 1 — LATE
+            public int LateCount;
+            public int LateFactoryOverdue;
+            public int LatePastETA;
+            public int LatePastLFD;
+            public int LateCustomsHold;
+
+            // Tile 2 — AT RISK $
+            public decimal AtRiskTotal;
+            public decimal AtRiskDemurrage;
+            public decimal AtRiskCustomsHoldCost;
+
+            // Tile 3 — PIPELINE (stage counts)
+            public int PipelineBooked;
+            public int PipelineInTransit;
+            public int PipelineAtPort;
+            public int PipelineCustoms;
         }
 
         /// <summary>
@@ -34,11 +38,12 @@ namespace StudioB.Containers
         /// </summary>
         public struct MetricsData
         {
-            public decimal Position;         // Total open PO value
-            public decimal CrossDockRate;    // % of containers with SO commitment
-            public decimal Speculation;      // PO value without SO coverage
+            public decimal OpenPOValue;
+            public decimal CrossDockRate;
+            public decimal CrossDockedYards;
+            public decimal TotalYards;
+            public decimal UncoveredValue;
             public int ActiveContainerCount;
-            public int ContainersWithSO;
         }
 
         public static string Build(KPIData data, MetricsData metrics = default)
@@ -54,84 +59,72 @@ namespace StudioB.Containers
 
             sb.Append("<div class='cmd-tile-row'>");
 
-            // ----- Tile 1: ACTION REQUIRED -----
-            bool actionEmpty = data.ActionCount == 0;
+            // ----- Tile 1: LATE -----
+            bool lateEmpty = data.LateCount == 0;
             sb.AppendFormat(
                 "<div class='cmd-tile cmd-tile-critical{0}' onclick=\"sb501000SetViewMode('EXCEPTIONS')\">",
-                actionEmpty ? " cmd-tile-empty" : "");
+                lateEmpty ? " cmd-tile-empty" : "");
             sb.Append("<div class='cmd-tile-header'>");
             sb.Append("<span class='cmd-tile-marker'>&#9679;</span>"); // ●
-            sb.Append("<span class='cmd-tile-label'>ACTION</span>");
+            sb.Append("<span class='cmd-tile-label'>LATE</span>");
             sb.Append("</div>");
-            sb.AppendFormat("<div class='cmd-tile-number'>{0}</div>", data.ActionCount);
+            sb.AppendFormat("<div class='cmd-tile-number'>{0}</div>", data.LateCount);
             sb.AppendFormat("<div class='cmd-tile-sublabel'>{0}</div>",
-                actionEmpty ? "NO CRITICAL ITEMS" : "CONTAINERS NEED ACTION");
+                lateEmpty ? "NO LATE ITEMS" : "CONTAINERS LATE");
 
-            if (!actionEmpty)
+            if (!lateEmpty)
             {
                 sb.Append("<div class='cmd-tile-subtext'>");
-                if (data.ActionPastLFD > 0)
-                    sb.AppendFormat("<div>&bull; {0} PAST LFD &middot; {1}/DAY</div>",
-                        data.ActionPastLFD, FormatMoney(data.ActionPastLFDDailyRate));
-                if (data.ActionCustomsHold > 0)
-                    sb.AppendFormat("<div>&bull; {0} CUSTOMS HOLD &gt; 2D</div>", data.ActionCustomsHold);
-                if (data.ActionISFCutoff > 0)
-                    sb.AppendFormat("<div>&bull; {0} ISF CUTOFF &lt; 14D</div>", data.ActionISFCutoff);
+                if (data.LateFactoryOverdue > 0)
+                    sb.AppendFormat("<div>&bull; {0} FACTORY OVERDUE</div>", data.LateFactoryOverdue);
+                if (data.LatePastETA > 0)
+                    sb.AppendFormat("<div>&bull; {0} PAST ETA</div>", data.LatePastETA);
+                if (data.LatePastLFD > 0)
+                    sb.AppendFormat("<div>&bull; {0} PAST LFD</div>", data.LatePastLFD);
+                if (data.LateCustomsHold > 0)
+                    sb.AppendFormat("<div>&bull; {0} CUSTOMS HOLD</div>", data.LateCustomsHold);
                 sb.Append("</div>");
             }
             sb.Append("</div>");
 
-            // ----- Tile 2: WATCH -----
-            bool watchEmpty = data.WatchCount == 0;
+            // ----- Tile 2: AT RISK -----
+            bool riskEmpty = data.AtRiskTotal == 0m;
             sb.AppendFormat(
                 "<div class='cmd-tile cmd-tile-warning{0}' onclick=\"sb501000SetViewMode('WATCH')\">",
-                watchEmpty ? " cmd-tile-empty" : "");
+                riskEmpty ? " cmd-tile-empty" : "");
             sb.Append("<div class='cmd-tile-header'>");
             sb.Append("<span class='cmd-tile-marker cmd-tile-marker-warning'>&#9670;</span>"); // ◆
-            sb.Append("<span class='cmd-tile-label cmd-tile-label-warning'>WATCH</span>");
+            sb.Append("<span class='cmd-tile-label cmd-tile-label-warning'>AT RISK</span>");
             sb.Append("</div>");
-            sb.AppendFormat("<div class='cmd-tile-number cmd-tile-number-warning'>{0}</div>", data.WatchCount);
+            sb.AppendFormat("<div class='cmd-tile-number cmd-tile-number-warning'>{0}</div>",
+                FormatMoney(data.AtRiskTotal));
             sb.AppendFormat("<div class='cmd-tile-sublabel'>{0}</div>",
-                watchEmpty ? "NOTHING ON WATCH" : "CONTAINERS ON WATCHLIST");
+                riskEmpty ? "NO RISK EXPOSURE" : "ACCRUING COST");
 
-            if (!watchEmpty)
+            if (!riskEmpty)
             {
                 sb.Append("<div class='cmd-tile-subtext'>");
-                if (data.WatchEtaSlipped > 0)
-                    sb.AppendFormat("<div>&bull; {0} ETA SLIPPED 7D</div>", data.WatchEtaSlipped);
-                if (data.WatchDocsIncomplete > 0)
-                    sb.AppendFormat("<div>&bull; {0} DOCS INCOMPLETE</div>", data.WatchDocsIncomplete);
-                if (data.WatchArrivingSoon > 0)
-                    sb.AppendFormat("<div>&bull; {0} ARRIVE IN 7D</div>", data.WatchArrivingSoon);
+                if (data.AtRiskDemurrage > 0m)
+                    sb.AppendFormat("<div>&bull; {0} DEMURRAGE</div>", FormatMoney(data.AtRiskDemurrage));
+                if (data.AtRiskCustomsHoldCost > 0m)
+                    sb.AppendFormat("<div>&bull; {0} CUSTOMS HOLD</div>", FormatMoney(data.AtRiskCustomsHoldCost));
                 sb.Append("</div>");
             }
             sb.Append("</div>");
 
-            // ----- Tile 3: $ EXPOSURE -----
-            bool exposureEmpty = data.ExposureTotal == 0m;
-            sb.AppendFormat(
-                "<div class='cmd-tile cmd-tile-exposure{0}' onclick=\"sb501000ShowExposurePanel()\">",
-                exposureEmpty ? " cmd-tile-empty" : "");
+            // ----- Tile 3: PIPELINE -----
+            int pipelineTotal = data.PipelineBooked + data.PipelineInTransit
+                + data.PipelineAtPort + data.PipelineCustoms;
+            sb.Append("<div class='cmd-tile cmd-tile-exposure'>");
             sb.Append("<div class='cmd-tile-header'>");
-            sb.Append("<span class='cmd-tile-marker cmd-tile-marker-accent'>$</span>");
-            sb.Append("<span class='cmd-tile-label cmd-tile-label-accent'>EXPOSURE</span>");
+            sb.Append("<span class='cmd-tile-marker cmd-tile-marker-accent'>&#8801;</span>"); // ≡
+            sb.Append("<span class='cmd-tile-label cmd-tile-label-accent'>PIPELINE</span>");
             sb.Append("</div>");
-            sb.AppendFormat("<div class='cmd-tile-number cmd-tile-number-exposure'>{0}</div>",
-                FormatMoney(data.ExposureTotal));
-            sb.AppendFormat("<div class='cmd-tile-sublabel'>{0}</div>",
-                exposureEmpty ? "NO EXPOSURE" : "AT RISK THIS WEEK");
-
-            if (!exposureEmpty)
-            {
-                sb.Append("<div class='cmd-tile-subtext'>");
-                if (data.ExposureDemurrage > 0m)
-                    sb.AppendFormat("<div>&bull; {0} DEMURRAGE</div>", FormatMoney(data.ExposureDemurrage));
-                if (data.ExposureDutyVariance > 0m)
-                    sb.AppendFormat("<div>&bull; {0} DUTY VAR</div>", FormatMoney(data.ExposureDutyVariance));
-                if (data.ExposureOther > 0m)
-                    sb.AppendFormat("<div>&bull; {0} OTHER</div>", FormatMoney(data.ExposureOther));
-                sb.Append("</div>");
-            }
+            sb.Append("<div class='cmd-tile-pipeline-counts'>");
+            sb.AppendFormat("BOOKED {0} &middot; IN TRANSIT {1}<br/>", data.PipelineBooked, data.PipelineInTransit);
+            sb.AppendFormat("AT PORT {0} &middot; CUSTOMS {1}", data.PipelineAtPort, data.PipelineCustoms);
+            sb.Append("</div>");
+            sb.AppendFormat("<div class='cmd-tile-sublabel'>{0} ACTIVE CONTAINERS</div>", pipelineTotal);
             sb.Append("</div>");
 
             sb.Append("</div>"); // cmd-tile-row
@@ -155,25 +148,27 @@ namespace StudioB.Containers
             var sb = new StringBuilder(512);
             sb.Append("<div class='cmd-metrics-row'>");
 
-            // Metric 1: OPEN PO VALUE (was "Position" internally)
+            // Metric 1: OPEN PO VALUE
             sb.Append("<div class='cmd-metric'>");
             sb.Append("<div class='cmd-metric-label'>OPEN PO VALUE</div>");
-            sb.AppendFormat("<div class='cmd-metric-value'>{0}</div>", FormatMoney(m.Position));
+            sb.AppendFormat("<div class='cmd-metric-value'>{0}</div>", FormatMoney(m.OpenPOValue));
             sb.Append("<div class='cmd-metric-sublabel'>ACROSS ACTIVE CONTAINERS</div>");
             sb.Append("</div>");
 
-            // Metric 2: CROSS-DOCK RATE
+            // Metric 2: CROSS-DOCK RATE (yard-based)
             sb.Append("<div class='cmd-metric'>");
             sb.Append("<div class='cmd-metric-label'>CROSS-DOCK RATE</div>");
             sb.AppendFormat("<div class='cmd-metric-value'>{0:0}%</div>", m.CrossDockRate);
-            sb.AppendFormat("<div class='cmd-metric-sublabel'>{0} OF {1} CONTAINERS WITH SO</div>",
-                m.ContainersWithSO, m.ActiveContainerCount);
+            sb.AppendFormat("<div class='cmd-metric-sublabel'>{0}</div>",
+                m.TotalYards > 0m
+                    ? string.Format("{0} OF {1} YDS", FormatYards(m.CrossDockedYards), FormatYards(m.TotalYards))
+                    : "NO ACTIVE PO LINES");
             sb.Append("</div>");
 
-            // Metric 3: UNCOVERED VALUE (was "Speculation" internally)
+            // Metric 3: UNCOVERED VALUE
             sb.Append("<div class='cmd-metric'>");
             sb.Append("<div class='cmd-metric-label'>UNCOVERED VALUE</div>");
-            sb.AppendFormat("<div class='cmd-metric-value'>{0}</div>", FormatMoney(m.Speculation));
+            sb.AppendFormat("<div class='cmd-metric-value'>{0}</div>", FormatMoney(m.UncoveredValue));
             sb.Append("<div class='cmd-metric-sublabel'>PO VALUE WITHOUT SO COVERAGE</div>");
             sb.Append("</div>");
 
@@ -185,6 +180,11 @@ namespace StudioB.Containers
         {
             if (amount == 0m) return "$0";
             return amount.ToString("C0", CultureInfo.GetCultureInfo("en-US"));
+        }
+
+        private static string FormatYards(decimal yards)
+        {
+            return yards.ToString("N0", CultureInfo.GetCultureInfo("en-US"));
         }
 
         private const string EmbeddedStyles = @"
@@ -230,6 +230,14 @@ namespace StudioB.Containers
 .cmd-tile-sublabel { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: #4a5568; margin-bottom: 6px; }
 .cmd-tile-subtext { font-size: 11px; color: #4a5568; line-height: 1.45; font-variant-numeric: tabular-nums; }
 .cmd-tile-subtext div { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cmd-tile-pipeline-counts {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: #1d3557;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 2px;
+}
 
 /* --- Phase C: Grid row risk coloring --- */
 /* Applied by ContainerGridRowColorScript to <tr> rows based on RiskLevel cell. */

--- a/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
@@ -328,6 +328,14 @@ window.sb501000SetViewMode = function(mode) {
     }
   } catch(e) { console.error('sb501000SetViewMode failed', e); }
 };
+window.sb501000OnGridDblClick = function(sender, args) {
+  try {
+    var ds = px_alls['ds'];
+    if (ds && ds.executeCallback) {
+      ds.executeCallback('OpenContainerDetail');
+    }
+  } catch(e) { console.error('sb501000OnGridDblClick failed', e); }
+};
 /* --- Phase D: update tabDetail tab labels from TabLabelsJson hidden field --- */
 window.sb501000ApplyTabLabels = function() {
   try {

--- a/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
@@ -6,8 +6,8 @@ namespace StudioB.Containers
 {
     /// <summary>
     /// Builds the HTML string for the SB501000 KPI tile row.
-    /// Follows the approved tile spec from docs/plans/2026-04-07-sb501000-kpi-tile-approved.md.
-    /// Three tiles: ACTION REQUIRED (red), WATCH (amber), $ EXPOSURE (accent).
+    /// Follows the approved PCC redesign spec from docs/plans/2026-04-11-pcc-redesign-design.md.
+    /// Three tiles: LATE (red), AT RISK $ (amber), PIPELINE (accent).
     /// </summary>
     public static class ContainerKPITileBuilder
     {
@@ -328,15 +328,6 @@ window.sb501000SetViewMode = function(mode) {
     }
   } catch(e) { console.error('sb501000SetViewMode failed', e); }
 };
-window.sb501000ShowExposurePanel = function() {
-  try {
-    var ds = px_alls['ds'];
-    if (ds && ds.executeCallback) {
-      ds.executeCallback('ShowExposurePanel');
-    }
-  } catch(e) { console.error('sb501000ShowExposurePanel failed', e); }
-};
-
 /* --- Phase D: update tabDetail tab labels from TabLabelsJson hidden field --- */
 window.sb501000ApplyTabLabels = function() {
   try {

--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -778,6 +778,7 @@ namespace StudioB.Containers
             // Command Center tile data
             var tile = new ContainerKPITileBuilder.KPIData();
             var metrics = new ContainerKPITileBuilder.MetricsData();
+            decimal totalPOValue = 0m;
 
             foreach (UsrContainer c in SelectFrom<UsrContainer>.View.Select(this))
             {
@@ -789,16 +790,69 @@ namespace StudioB.Containers
                 if (status == ContainerStatus.CustomsHold) customsHold++;
                 if (c.ETA != null && c.ETA >= weekStart && c.ETA < weekEnd) arrivingThisWeek++;
 
+                // --- Pipeline stage counts (before skipping terminal) ---
+                switch (status)
+                {
+                    case ContainerStatus.Booked: tile.PipelineBooked++; break;
+                    case ContainerStatus.Departed:
+                    case ContainerStatus.InTransit: tile.PipelineInTransit++; break;
+                    case ContainerStatus.Arrived:
+                    case ContainerStatus.Discharged: tile.PipelineAtPort++; break;
+                    case ContainerStatus.CustomsHold: tile.PipelineCustoms++; break;
+                }
+
                 // Skip terminal states from risk aggregation
                 if (status == ContainerStatus.Delivered || status == ContainerStatus.Cancelled)
                     continue;
 
                 // --- Portfolio metrics (active containers only) ---
                 metrics.ActiveContainerCount++;
+
+                int holdDays = ContainerRiskCalculator.CustomsHoldDays(today, status, c.LastSyncDate);
+
+                // --- Tile 1: LATE ---
+                bool isLate = false;
+
+                if (c.FactoryPromisedDate.HasValue && c.FactoryPromisedDate.Value.Date < today.Date
+                    && !c.FactoryActualDate.HasValue)
+                {
+                    tile.LateFactoryOverdue++;
+                    isLate = true;
+                }
+                if (c.ETA.HasValue && c.ETA.Value.Date < today.Date && !c.ATA.HasValue
+                    && status != ContainerStatus.Delivered && status != ContainerStatus.Cancelled)
+                {
+                    tile.LatePastETA++;
+                    isLate = true;
+                }
+                if (c.LastFreeDay.HasValue && c.LastFreeDay.Value.Date < today.Date)
+                {
+                    tile.LatePastLFD++;
+                    isLate = true;
+                }
+                if (status == ContainerStatus.CustomsHold && holdDays > 3)
+                {
+                    tile.LateCustomsHold++;
+                    isLate = true;
+                }
+                if (isLate)
+                    tile.LateCount++;
+
+                // --- Tile 2: AT RISK $ ---
+                decimal demurrageExposure = ContainerRiskCalculator.ComputeDemurrageExposure(
+                    today, c.LastFreeDay, c.DemurrageDailyRate,
+                    customsHoldDays: holdDays,
+                    customsHoldEstimatedCostPerDay: null);
+                tile.AtRiskDemurrage += demurrageExposure;
+
+                // Customs hold estimated cost: $150/day as a default
+                if (holdDays > 0)
+                    tile.AtRiskCustomsHoldCost += holdDays * 150m;
+
+                // --- Yard-based cross-dock metrics ---
                 if (c.ContainerID.HasValue)
                 {
                     decimal containerPOValue = 0m;
-                    bool hasSOMatch = false;
                     foreach (PXResult<UsrContainerPOLink, POLine> plr in SelectFrom<UsrContainerPOLink>
                         .LeftJoin<POLine>.On<POLine.orderType.IsEqual<UsrContainerPOLink.orderType>
                             .And<POLine.orderNbr.IsEqual<UsrContainerPOLink.orderNbr>>
@@ -807,115 +861,46 @@ namespace StudioB.Containers
                         .View.Select(this, c.ContainerID))
                     {
                         var poLine = (POLine)plr;
-                        if (poLine?.ExtCost != null) containerPOValue += poLine.ExtCost.Value;
 
-                        // Check for SO commitment via InventoryID match
-                        if (!hasSOMatch && poLine?.InventoryID != null)
+                        // For each PO line, compute yard-based cross-dock
+                        if (poLine?.OrderQty != null && poLine.OrderQty.Value > 0m)
                         {
-                            var soMatch = SelectFrom<PX.Objects.SO.SOLine>
-                                .Where<PX.Objects.SO.SOLine.inventoryID.IsEqual<@P.AsInt>
-                                    .And<PX.Objects.SO.SOLine.completed.IsEqual<False>>>
-                                .View.SelectSingleBound(this, null, poLine.InventoryID);
-                            if (soMatch != null) hasSOMatch = true;
+                            metrics.TotalYards += poLine.OrderQty.Value;
+                            containerPOValue += poLine.ExtCost ?? 0m;
+
+                            // Find matching open SO lines for this InventoryID
+                            if (poLine.InventoryID != null)
+                            {
+                                decimal soQtySum = 0m;
+                                foreach (PX.Objects.SO.SOLine soLine in SelectFrom<PX.Objects.SO.SOLine>
+                                    .Where<PX.Objects.SO.SOLine.inventoryID.IsEqual<@P.AsInt>
+                                        .And<PX.Objects.SO.SOLine.completed.IsEqual<False>>>
+                                    .View.Select(this, poLine.InventoryID))
+                                {
+                                    soQtySum += soLine.OrderQty ?? 0m;
+                                }
+                                decimal crossDockedQty = Math.Min(poLine.OrderQty.Value, soQtySum);
+                                metrics.CrossDockedYards += crossDockedQty;
+
+                                // Uncovered proportion of this PO line's value
+                                decimal uncoveredQty = poLine.OrderQty.Value - crossDockedQty;
+                                if (uncoveredQty > 0m && poLine.OrderQty.Value > 0m)
+                                {
+                                    metrics.UncoveredValue += (poLine.ExtCost ?? 0m) * (uncoveredQty / poLine.OrderQty.Value);
+                                }
+                            }
                         }
                     }
-                    metrics.Position += containerPOValue;
-                    if (hasSOMatch)
-                    {
-                        metrics.ContainersWithSO++;
-                        // Cross-dock: this PO value has SO backing
-                    }
-                    else
-                    {
-                        metrics.Speculation += containerPOValue;
-                    }
-                }
-
-                // --- Risk level (with doc/ETA counts for accurate KPI tiles) ---
-                int holdDays = ContainerRiskCalculator.CustomsHoldDays(today, status, c.LastSyncDate);
-
-                // Doc counts per container — N+1 is acceptable at 5-10 active containers
-                int cDocsReq = 0, cDocsRcv = 0;
-                if (c.ContainerID.HasValue)
-                {
-                    foreach (UsrContainerDocument d in SelectFrom<UsrContainerDocument>
-                        .Where<UsrContainerDocument.containerID.IsEqual<@P.AsInt>>
-                        .View.Select(this, c.ContainerID))
-                    {
-                        if (d.Required == true) cDocsReq++;
-                        if (d.Status == "RECEIVED" || d.Status == "VERIFIED") cDocsRcv++;
-                    }
-                }
-
-                // ETA change count (last 7 days)
-                int cEtaChanges = 0;
-                if (c.ContainerID.HasValue)
-                {
-                    DateTime sevenDaysAgo = today.AddDays(-7);
-                    foreach (UsrContainerETAHistory h in SelectFrom<UsrContainerETAHistory>
-                        .Where<UsrContainerETAHistory.containerID.IsEqual<@P.AsInt>
-                            .And<UsrContainerETAHistory.recordedDate.IsGreaterEqual<@P.AsDateTime>>>
-                        .View.Select(this, c.ContainerID, sevenDaysAgo))
-                    {
-                        cEtaChanges++;
-                    }
-                }
-
-                string rl = ContainerRiskCalculator.ComputeRiskLevel(
-                    today, status, c.LastFreeDay, c.ETA, c.ISFFiledDate, c.DepartedDate,
-                    docsRequired: cDocsReq, docsReceived: cDocsRcv,
-                    etaChangesLast7Days: cEtaChanges, customsHoldDays: holdDays);
-
-                // --- Tile 1 breakdown ---
-                if (rl == ContainerRiskCalculator.RiskCritical)
-                {
-                    tile.ActionCount++;
-
-                    if (c.LastFreeDay.HasValue && c.LastFreeDay.Value.Date < today.Date)
-                    {
-                        tile.ActionPastLFD++;
-                        if (c.DemurrageDailyRate.HasValue)
-                            tile.ActionPastLFDDailyRate += c.DemurrageDailyRate.Value;
-                    }
-                    if (status == ContainerStatus.CustomsHold && holdDays > 2)
-                        tile.ActionCustomsHold++;
-                    if (!c.ISFFiledDate.HasValue && !c.DepartedDate.HasValue &&
-                        status == ContainerStatus.Booked &&
-                        c.ETA.HasValue && (c.ETA.Value.Date - today.Date).TotalDays < 14)
-                        tile.ActionISFCutoff++;
-                }
-                // --- Tile 2 breakdown ---
-                else if (rl == ContainerRiskCalculator.RiskWarning)
-                {
-                    tile.WatchCount++;
-
-                    if (c.LastFreeDay.HasValue &&
-                        (c.LastFreeDay.Value.Date - today.Date).TotalDays <= 3)
-                    {
-                        // LFD-soon counted in ETA slipped bucket only if it's not already action-level
-                    }
-                    if (c.ETA.HasValue &&
-                        c.ETA.Value.Date <= horizon7.Date &&
-                        c.ETA.Value.Date >= today.Date)
-                        tile.WatchArrivingSoon++;
-                }
-
-                // --- Tile 3 exposure ---
-                decimal exposure = ContainerRiskCalculator.ComputeDemurrageExposure(
-                    today, c.LastFreeDay, c.DemurrageDailyRate,
-                    customsHoldDays: holdDays,
-                    customsHoldEstimatedCostPerDay: null);
-                if (exposure > 0m)
-                {
-                    tile.ExposureDemurrage += exposure;
+                    totalPOValue += containerPOValue;
                 }
             }
 
-            tile.ExposureTotal = tile.ExposureDemurrage + tile.ExposureDutyVariance + tile.ExposureOther;
+            tile.AtRiskTotal = tile.AtRiskDemurrage + tile.AtRiskCustomsHoldCost;
 
-            // Compute cross-dock rate
-            metrics.CrossDockRate = metrics.ActiveContainerCount > 0
-                ? (decimal)metrics.ContainersWithSO / metrics.ActiveContainerCount * 100m
+            // Compute yard-based cross-dock rate
+            metrics.OpenPOValue = totalPOValue;
+            metrics.CrossDockRate = metrics.TotalYards > 0m
+                ? metrics.CrossDockedYards / metrics.TotalYards * 100m
                 : 0m;
 
             // Assign legacy fields for backwards compat
@@ -924,10 +909,9 @@ namespace StudioB.Containers
             e.Row.KPIArrivingThisWeek = arrivingThisWeek;
             e.Row.KPICustomsHold = customsHold;
 
-            // Assign Command Center tile fields
-            e.Row.KPIActionCount = tile.ActionCount;
-            e.Row.KPIWatchCount = tile.WatchCount;
-            e.Row.KPIExposureTotal = tile.ExposureTotal;
+            // Assign new tile fields
+            e.Row.KPILateCount = tile.LateCount;
+            e.Row.KPIAtRiskTotal = tile.AtRiskTotal;
             e.Row.KPITilesHtml = ContainerKPITileBuilder.Build(tile, metrics);
         }
 

--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -229,7 +229,9 @@ namespace StudioB.Containers
                 docsRequired: 0,
                 docsReceived: 0,
                 etaChangesLast7Days: 0,
-                customsHoldDays: customsHoldDays);
+                customsHoldDays: customsHoldDays,
+                factoryPromisedDate: row.FactoryPromisedDate,
+                factoryActualDate: row.FactoryActualDate);
         }
         #endregion
 
@@ -970,7 +972,9 @@ namespace StudioB.Containers
 
             row.RiskLevel = ContainerRiskCalculator.ComputeRiskLevel(
                 today, row.Status, row.LastFreeDay, row.ETA, row.ISFFiledDate, row.DepartedDate,
-                docsRequired, docsReceived, etaChanges, holdDays);
+                docsRequired, docsReceived, etaChanges, holdDays,
+                factoryPromisedDate: row.FactoryPromisedDate,
+                factoryActualDate: row.FactoryActualDate);
 
             if (row.LastFreeDay.HasValue)
                 row.DaysToLFD = (int)(row.LastFreeDay.Value.Date - today.Date).TotalDays;
@@ -1060,6 +1064,10 @@ namespace StudioB.Containers
                 OrderDate = earliestOrderDate,
                 AcknowledgedDate = latestAckedDate,
                 FactoryReadyDate = latestFactoryReadyDate,
+                // Container-level mill/factory dates
+                FactoryPromisedDate = row.FactoryPromisedDate,
+                FactoryActualDate = row.FactoryActualDate,
+                MillAckDate = row.MillAckDate,
                 // Container-sourced dates
                 BookedDate = row.BookedDate,
                 DepartedDate = row.DepartedDate,

--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -253,6 +253,8 @@ namespace StudioB.Containers
             public class delivered : BqlString.Constant<delivered> { public delivered() : base(Delivered) { } }
             public class cancelled : BqlString.Constant<cancelled> { public cancelled() : base(Cancelled) { } }
         }
+
+        private const decimal DefaultCustomsHoldCostPerDay = 150m;
         #endregion
 
         #region Actions
@@ -847,7 +849,7 @@ namespace StudioB.Containers
 
                 // Customs hold estimated cost: $150/day as a default
                 if (holdDays > 0)
-                    tile.AtRiskCustomsHoldCost += holdDays * 150m;
+                    tile.AtRiskCustomsHoldCost += holdDays * DefaultCustomsHoldCostPerDay;
 
                 // --- Yard-based cross-dock metrics ---
                 if (c.ContainerID.HasValue)

--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -260,6 +260,15 @@ namespace StudioB.Containers
         #endregion
 
         #region Actions
+        public PXAction<ContainerFilter> OpenContainerDetail;
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Open Detail", MapEnableRights = PXCacheRights.Select)]
+        protected void openContainerDetail()
+        {
+            if (Container.Current == null) return;
+            Container.AskExt();
+        }
+
         public PXAction<ContainerFilter> RefreshTracking;
         [PXButton(CommitChanges = true)]
         [PXUIField(DisplayName = "Refresh Tracking", MapEnableRights = PXCacheRights.Update)]

--- a/src/StudioB.Containers/Graphs/ContainerRiskCalculator.cs
+++ b/src/StudioB.Containers/Graphs/ContainerRiskCalculator.cs
@@ -28,7 +28,9 @@ namespace StudioB.Containers
             int docsRequired,
             int docsReceived,
             int etaChangesLast7Days,
-            int customsHoldDays)
+            int customsHoldDays,
+            DateTime? factoryPromisedDate = null,
+            DateTime? factoryActualDate = null)
         {
             // ----- CRITICAL triggers -----
             if (lastFreeDay.HasValue && lastFreeDay.Value.Date < today.Date)
@@ -61,6 +63,11 @@ namespace StudioB.Containers
                 return RiskWarning;
 
             if (docsRequired > 0 && docsReceived < docsRequired)
+                return RiskWarning;
+
+            // Factory date overdue — promised date passed without actual
+            if (factoryPromisedDate.HasValue && !factoryActualDate.HasValue &&
+                factoryPromisedDate.Value.Date < today.Date)
                 return RiskWarning;
 
             return RiskOk;

--- a/src/StudioB.Containers/Graphs/ContainerTimelineBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerTimelineBuilder.cs
@@ -36,6 +36,10 @@ namespace StudioB.Containers
             public DateTime? ETA;
             public DateTime? ATA;
             public int? CustomsHoldDays;
+            // Container-level mill/factory dates (preferred over PO-sourced)
+            public DateTime? FactoryPromisedDate;  // Mill's promised ready date
+            public DateTime? FactoryActualDate;    // When goods were actually ready
+            public DateTime? MillAckDate;          // When mill acknowledged
             // Legacy — kept for backwards compat but no longer drives a stop
             public DateTime? BookedDate;
         }
@@ -48,6 +52,8 @@ namespace StudioB.Containers
             public DateTime? EstimatedDate;
             public bool IsCurrent;
             public bool IsAlert;  // customs hold, etc.
+            public bool IsWarning;      // yellow — within 5 days of due
+            public DateTime? SecondaryDate; // for showing promised vs actual side-by-side
         }
 
         public static string Build(TimelineData data)
@@ -68,6 +74,7 @@ namespace StudioB.Containers
                 if (isComplete) cls += " tl-complete";
                 if (s.IsCurrent) cls += " tl-current";
                 if (s.IsAlert) cls += " tl-alert";
+                if (s.IsWarning) cls += " tl-warning";
 
                 sb.AppendFormat("<div class='{0}'>", cls);
                 sb.Append("<div class='tl-marker'>");
@@ -100,8 +107,13 @@ namespace StudioB.Containers
             var stops = new Stop[8];
             // PO-sourced stages
             stops[0] = new Stop { Key = "PLACED",    Label = "PLACED",        ActualDate = d.OrderDate };
-            stops[1] = new Stop { Key = "ACKED",     Label = "ACKED",         ActualDate = d.AcknowledgedDate };
-            stops[2] = new Stop { Key = "FACTORY",   Label = "FACTORY READY", ActualDate = d.FactoryReadyDate };
+            stops[1] = new Stop { Key = "ACKED",     Label = "ACKED",         ActualDate = d.MillAckDate ?? d.AcknowledgedDate };
+            stops[2] = new Stop {
+                Key = "FACTORY", Label = "FACTORY READY",
+                ActualDate = d.FactoryActualDate ?? d.FactoryReadyDate,
+                EstimatedDate = d.FactoryPromisedDate,
+                SecondaryDate = d.FactoryPromisedDate,
+            };
             // Container-sourced stages
             stops[3] = new Stop { Key = "SHIPPED",   Label = "SHIPPED",       ActualDate = d.DepartedDate, EstimatedDate = d.ETD };
             stops[4] = new Stop { Key = "TRANSIT",   Label = "IN TRANSIT",    ActualDate = null };
@@ -129,6 +141,30 @@ namespace StudioB.Containers
                 }
             }
 
+            // Color thresholds: red for overdue, yellow for approaching due
+            DateTime today = DateTime.Today;
+            for (int i = 0; i < stops.Length; i++)
+            {
+                if (stops[i].ActualDate.HasValue)
+                    continue; // complete = green, no warning/alert needed
+
+                DateTime? expectedDate = stops[i].EstimatedDate;
+                if (!expectedDate.HasValue) continue;
+
+                double daysUntil = (expectedDate.Value.Date - today).TotalDays;
+                if (daysUntil < 0)
+                    stops[i].IsAlert = true;   // past due = red
+                else if (daysUntil <= 5)
+                    stops[i].IsWarning = true; // within 5 days = yellow
+            }
+
+            // Special case: FACTORY READY — if actual > promised, mark as alert (was late)
+            if (d.FactoryActualDate.HasValue && d.FactoryPromisedDate.HasValue &&
+                d.FactoryActualDate.Value.Date > d.FactoryPromisedDate.Value.Date)
+            {
+                stops[2].IsAlert = true;
+            }
+
             return stops;
         }
 
@@ -153,7 +189,13 @@ namespace StudioB.Containers
         private static string FormatCellDate(Stop s)
         {
             if (s.ActualDate.HasValue)
-                return s.ActualDate.Value.ToString("MMM d");
+            {
+                string actual = s.ActualDate.Value.ToString("MMM d");
+                // Show promised → actual when factory was late
+                if (s.SecondaryDate.HasValue && s.SecondaryDate.Value.Date != s.ActualDate.Value.Date)
+                    return s.SecondaryDate.Value.ToString("MMM d") + " &rarr; " + actual;
+                return actual;
+            }
             if (s.EstimatedDate.HasValue)
                 return "~" + s.EstimatedDate.Value.ToString("MMM d");
             return "&nbsp;";
@@ -222,6 +264,13 @@ namespace StudioB.Containers
 .cmd-timeline-cell.tl-complete .tl-label { color: #2d8a5f; }
 .cmd-timeline-cell.tl-current .tl-label { color: #1d3557; font-weight: 700; }
 .cmd-timeline-cell.tl-alert .tl-label { color: #d64045; font-weight: 700; }
+.cmd-timeline-cell.tl-warning .tl-marker {
+  color: #fff;
+  background: #e8a33d;
+  border-color: #e8a33d;
+  box-shadow: 0 0 0 3px #fef5e7;
+}
+.cmd-timeline-cell.tl-warning .tl-label { color: #b37517; font-weight: 700; }
 .tl-connector {
   flex: 1 1 auto;
   height: 2px;


### PR DESCRIPTION
## Summary
- Removes `<ClientEvents AfterRowDblClick>` from PXGrid — not a valid PXGrid property, caused ASPX compilation failure on publish
- Detail panel opens via `LinkCommand="OpenContainerDetail"` on ContainerCD column instead (standard Acumatica pattern)
- Removes dead JS handler `sb501000OnGridDblClick` from KPI tile script

Follow-up to #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)