### PR TITLE
fix(pcc): remove invalid AfterRowDblClick ASPX property

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -80,7 +80,6 @@
         <AutoCallBack Command="Refresh" Target="frmTimeline" ActiveBehavior="True">
             <Behavior RepaintControlsIDs="frmTimeline" CommitChanges="True" />
         </AutoCallBack>
-        <ClientEvents AfterRowDblClick="sb501000OnGridDblClick" />
     </px:PXGrid>
 
     <%-- Slide-out detail panel (right-anchored) --%>

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -296,7 +296,6 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
         <AutoCallBack Command="Refresh" Target="frmTimeline" ActiveBehavior="True">
             <Behavior RepaintControlsIDs="frmTimeline" CommitChanges="True" />
         </AutoCallBack>
-        <ClientEvents AfterRowDblClick="sb501000OnGridDblClick" />
     </px:PXGrid>
 
     <%-- Slide-out detail panel (right-anchored) --%>

--- a/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerKPITileBuilder.cs
@@ -328,14 +328,6 @@ window.sb501000SetViewMode = function(mode) {
     }
   } catch(e) { console.error('sb501000SetViewMode failed', e); }
 };
-window.sb501000OnGridDblClick = function(sender, args) {
-  try {
-    var ds = px_alls['ds'];
-    if (ds && ds.executeCallback) {
-      ds.executeCallback('OpenContainerDetail');
-    }
-  } catch(e) { console.error('sb501000OnGridDblClick failed', e); }
-};
 /* --- Phase D: update tabDetail tab labels from TabLabelsJson hidden field --- */
 window.sb501000ApplyTabLabels = function() {
   try {


### PR DESCRIPTION
## Summary
- Removes `<ClientEvents AfterRowDblClick>` from PXGrid — not a valid property, caused ASPX compilation failure on publish
- Detail panel opens via `LinkCommand="OpenContainerDetail"` on ContainerCD column (standard Acumatica pattern)
- Removes dead JS handler from KPI tile script

Follow-up to #375 publish failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)