### PR TITLE
fix(pcc): enable Save + fix SmartPanel tab scrolling

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -2,7 +2,7 @@
 <%@ MasterType VirtualPath="~/MasterPages/FormDetail.master" %>
 <asp:Content ID="cont1" ContentPlaceHolderID="phDS" Runat="Server">
     <px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%"
-        TypeName="StudioB.Containers.ContainerMaint" PrimaryView="Filter">
+        TypeName="StudioB.Containers.ContainerMaint" PrimaryView="Containers">
         <CallbackCommands>
             <px:PXDSCallbackCommand CommitChanges="True" Name="Save" />
             <px:PXDSCallbackCommand Name="Insert" PostData="Self" />
@@ -88,7 +88,9 @@
         Caption="Container Detail" CaptionVisible="True"
         LoadOnDemand="True" Key="Container" AutoCallBack-Enabled="True"
         AutoCallBack-Target="frmDetail" AutoCallBack-ActiveBehavior="True"
-        ShowCloseButton="True" Width="600px" Height="100%">
+        AutoRepaint="True"
+        ShowCloseButton="True" Width="600px" Height="100%"
+        Style="overflow-y:auto;">
 
         <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
             Width="100%" CaptionVisible="False">
@@ -155,7 +157,7 @@
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="PO Links">
+                <px:PXTabItem Text="PO Links" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridPOLinks" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <ActionBar>
@@ -182,7 +184,7 @@
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="Costs">
+                <px:PXTabItem Text="Costs" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridCosts" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <Levels>
@@ -202,7 +204,7 @@
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="Documents">
+                <px:PXTabItem Text="Documents" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridDocuments" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <ActionBar>
@@ -225,7 +227,7 @@
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="ETA History">
+                <px:PXTabItem Text="ETA History" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridETAHistory" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <ActionBar>
@@ -248,7 +250,7 @@
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="Lead Time">
+                <px:PXTabItem Text="Lead Time" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
                             Width="100%" SkinID="Details">

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -218,7 +218,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
 <%@ MasterType VirtualPath="~/MasterPages/FormDetail.master" %>
 <asp:Content ID="cont1" ContentPlaceHolderID="phDS" Runat="Server">
     <px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%"
-        TypeName="StudioB.Containers.ContainerMaint" PrimaryView="Filter">
+        TypeName="StudioB.Containers.ContainerMaint" PrimaryView="Containers">
         <CallbackCommands>
             <px:PXDSCallbackCommand CommitChanges="True" Name="Save" />
             <px:PXDSCallbackCommand Name="Insert" PostData="Self" />
@@ -304,7 +304,9 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
         Caption="Container Detail" CaptionVisible="True"
         LoadOnDemand="True" Key="Container" AutoCallBack-Enabled="True"
         AutoCallBack-Target="frmDetail" AutoCallBack-ActiveBehavior="True"
-        ShowCloseButton="True" Width="600px" Height="100%">
+        AutoRepaint="True"
+        ShowCloseButton="True" Width="600px" Height="100%"
+        Style="overflow-y:auto;">
 
         <px:PXFormView ID="frmDetail" runat="server" DataSourceID="ds" DataMember="Container"
             Width="100%" CaptionVisible="False">
@@ -371,7 +373,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="PO Links">
+                <px:PXTabItem Text="PO Links" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridPOLinks" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <ActionBar>
@@ -398,7 +400,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="Costs">
+                <px:PXTabItem Text="Costs" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridCosts" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <Levels>
@@ -418,7 +420,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="Documents">
+                <px:PXTabItem Text="Documents" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridDocuments" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <ActionBar>
@@ -441,7 +443,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="ETA History">
+                <px:PXTabItem Text="ETA History" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridETAHistory" runat="server" DataSourceID="ds" Width="100%" SkinID="Details">
                             <ActionBar>
@@ -464,7 +466,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                         </px:PXGrid>
                     </Template>
                 </px:PXTabItem>
-                <px:PXTabItem Text="Lead Time">
+                <px:PXTabItem Text="Lead Time" RepaintOnDemand="False">
                     <Template>
                         <px:PXGrid ID="gridLeadTimes" runat="server" DataSourceID="ds"
                             Width="100%" SkinID="Details">


### PR DESCRIPTION
## Summary
- **Save fix:** `PrimaryView="Filter"` → `PrimaryView="Containers"` so Save persists UsrContainer data
- **Scroll fix:** SmartPanel tabs (PO Links, Costs, Documents, ETA History, Lead Time) now scroll correctly — added `AutoRepaint`, `overflow-y:auto`, and `RepaintOnDemand="False"` on all tab items

## Test plan
- [ ] Edit a container field (e.g., Carrier) and click Save — should persist
- [ ] Open SmartPanel, switch to PO Links tab — should scroll
- [ ] Switch to Costs, Documents, ETA History, Lead Time — all should scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)