### PR TITLE
fix(gi): correct DRP GI conditions — LineType codes + table order

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -2327,7 +2327,7 @@ public partial class Page_SB_SB302040 : PXPage
             <GIResult LineNbr="10" SortOrder="10" IsActive="1" Field="SiteID" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Site" RowID="7501a3a2-2147-4369-96f6-f44490f8440a" />
             <GIResult LineNbr="11" SortOrder="11" IsActive="1" Field="UOM" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="UOM" RowID="812a72b9-c8bc-47b8-a738-e839a814a529" />
           </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="SOLine.LineType" Condition="E " IsExpression="0" Value1="GoodsForInventory" Operation="A" />
+          <GIWhere LineNbr="1" IsActive="1" DataFieldName="SOLine.LineType" Condition="E " IsExpression="0" Value1="GI" Operation="A" />
           <GIWhere LineNbr="2" IsActive="1" DataFieldName="SOLine.OpenQty" Condition="G " IsExpression="0" Value1="0" Operation="A" />
           <GIWhere LineNbr="3" OpenBrackets="1" IsActive="1" DataFieldName="SOLine.OrderType" Condition="E " IsExpression="0" Value1="CO" Operation="A" />
           <GIWhere LineNbr="4" IsActive="1" DataFieldName="SOLine.OrderType" Condition="E " IsExpression="0" Value1="SO" Operation="O" />
@@ -2479,21 +2479,21 @@ public partial class Page_SB_SB302040 : PXPage
     <data>
       <GIDesign>
         <row DesignID="a5337a02-6d79-42e9-b400-d7178ac3fd24" Name="DRP_InventoryBySite" ScreenID="SB401110" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
-          <GITable Alias="INSiteStatus" Name="PX.Objects.IN.INSiteStatus">
-            <GIRelation LineNbr="1" ChildTable="InventoryItem" IsActive="1" JoinType="I">
+          <GITable Alias="InventoryItem" Name="PX.Objects.IN.InventoryItem">
+            <GIRelation LineNbr="1" ChildTable="INSiteStatus" IsActive="1" JoinType="I">
               <GIOn LineNbr="1" ParentField="InventoryID" Condition="E " ChildField="InventoryID" Operation="A" />
             </GIRelation>
+            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="InventoryCD" Width="120" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="79173e70-3a85-4d70-a5a4-cd71ae7ae80e" />
+            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="Descr" Width="220" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Description" RowID="872a8b14-9db6-4978-8214-32c8f5670646" />
+            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="ItemStatus" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Status" RowID="e24ba55f-863f-45be-a4f9-7ed06db4b49b" />
+            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="ItemClassID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Item Class" RowID="6b15d7cd-e2f1-4166-a7b4-b2b7c6fd1eed" />
+          </GITable>
+          <GITable Alias="INSiteStatus" Name="PX.Objects.IN.INSiteStatus">
             <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="SiteID" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Site" RowID="45834d20-dc12-430f-a291-9c8b3576f12a" />
             <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="QtyOnHand" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty On Hand" RowID="169233bb-3c3e-4657-8dcd-cba20887a558" />
             <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="QtyAvail" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty Available" RowID="8ce9d3cb-34ed-4983-85e3-00b844b380eb" />
             <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="QtyHardAvail" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty Hard Avail" RowID="d1cb550a-2817-4469-ab21-742e368f2ee5" />
             <GIResult LineNbr="9" SortOrder="9" IsActive="1" Field="QtyAllocated" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty Allocated" RowID="78f5dc04-3821-493e-822d-984b1805f2d5" />
-          </GITable>
-          <GITable Alias="InventoryItem" Name="PX.Objects.IN.InventoryItem">
-            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="InventoryCD" Width="120" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="79173e70-3a85-4d70-a5a4-cd71ae7ae80e" />
-            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="Descr" Width="220" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Description" RowID="872a8b14-9db6-4978-8214-32c8f5670646" />
-            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="ItemStatus" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Status" RowID="e24ba55f-863f-45be-a4f9-7ed06db4b49b" />
-            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="ItemClassID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Item Class" RowID="6b15d7cd-e2f1-4166-a7b4-b2b7c6fd1eed" />
           </GITable>
           <GIWhere LineNbr="1" IsActive="1" DataFieldName="InventoryItem.StkItem" Condition="E " IsExpression="0" Value1="True" Operation="A" />
           <GIWhere LineNbr="2" OpenBrackets="1" IsActive="1" DataFieldName="InventoryItem.ItemStatus" Condition="E " IsExpression="0" Value1="AC" Operation="A" />
@@ -2678,7 +2678,7 @@ public partial class Page_SB_SB302040 : PXPage
           <GITable Alias="Container" Name="StudioB.Containers.UsrContainer">
             <GIResult LineNbr="12" SortOrder="12" IsActive="1" Field="ContainerCD" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Container Nbr" RowID="93ed61d7-5194-4c5e-9c2e-dc02f6a7059b" />
           </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="Line.LineType" Condition="E " IsExpression="0" Value1="GoodsForInventory" Operation="A" />
+          <GIWhere LineNbr="1" IsActive="1" DataFieldName="Line.LineType" Condition="E " IsExpression="0" Value1="GI" Operation="A" />
           <GIWhere LineNbr="2" IsActive="1" DataFieldName="Line.OpenQty" Condition="G " IsExpression="0" Value1="0" Operation="A" />
           <GIWhere LineNbr="3" OpenBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="N" Operation="A" />
           <GIWhere LineNbr="4" CloseBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="O" Operation="O" />


### PR DESCRIPTION
## Summary
- **DRP_OpenSOCommitments** + **DRP_OpenPOLines**: `LineType` condition used C# constant name `GoodsForInventory` instead of DAC internal code `GI` — no rows ever matched
- **DRP_InventoryBySite**: Swapped table order so `InventoryItem` is parent with `INNER JOIN` to `INSiteStatus` (matches working `InventoryQuantityDetail` GI pattern)

All 3 GIs were returning 200 with 0 rows. `DRP_VelocityHistory` (the 4th DRP GI) was unaffected and working correctly.

## Test plan
- [ ] Deploy via CI/CD pipeline (after hours)
- [ ] Verify all 4 GIs return data via OData: `GET /t/Heritage%20Fabrics/api/odata/gi/DRP_InventoryBySite?$top=5`
- [ ] Trigger DRP agent run: `POST /api/drp/config/run-now`
- [ ] Confirm signal caches populated in heritage-wms DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)