### PR TITLE
chore: extend GCE VM schedule 10am-midnight CT

### DIFF
--- a/.github/workflows/vm-autostart.yml
+++ b/.github/workflows/vm-autostart.yml
@@ -1,16 +1,17 @@
-# VM Auto-Start — ensure acumatica-test is running before business hours
+# VM Auto-Start — ensure acumatica-test is running during working hours
 #
 # The acumatica-test GCE VM goes offline (auto-shutdown or preemption)
 # and blocks the build-validate job which runs on self-hosted Windows.
-# This workflow starts it at 8:00 AM ET (12:00 UTC) on weekdays.
+# This workflow starts it at 10:00 AM CT (15:00 UTC CDT) daily.
+# Paired with vm-autostop.yml which shuts it down at midnight CT.
 
 name: VM Auto-Start
 
 on:
   schedule:
-    # 12:00 UTC = 8:00 AM ET (EDT), 7:00 AM ET (EST)
-    # Weekdays only
-    - cron: '0 12 * * 1-5'
+    # 15:00 UTC = 10:00 AM CT (CDT), 9:00 AM CT (CST)
+    # Daily (deploys can happen on weekends)
+    - cron: '3 15 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/vm-autostop.yml
+++ b/.github/workflows/vm-autostop.yml
@@ -1,0 +1,50 @@
+# VM Auto-Stop — shut down acumatica-test at midnight CT
+#
+# Saves GCE compute costs by stopping the self-hosted Windows runner
+# after working hours. Paired with vm-autostart.yml (10 AM CT daily).
+
+name: VM Auto-Stop
+
+on:
+  schedule:
+    # 05:00 UTC = 12:00 AM CT (CDT), 11:00 PM CT (CST)
+    # Daily
+    - cron: '2 5 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write   # Required for Workload Identity Federation
+
+jobs:
+  stop-vm:
+    name: Stop acumatica-test VM
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Stop VM if running
+        run: |
+          STATUS=$(gcloud compute instances describe acumatica-test \
+            --zone=us-central1-a \
+            --format='get(status)' 2>/dev/null || echo "UNKNOWN")
+
+          echo "Current VM status: $STATUS"
+
+          if [ "$STATUS" = "RUNNING" ]; then
+            echo "Stopping acumatica-test..."
+            gcloud compute instances stop acumatica-test --zone=us-central1-a
+            echo "::notice::acumatica-test VM stopped for overnight cost savings"
+          elif [ "$STATUS" = "TERMINATED" ] || [ "$STATUS" = "STOPPED" ]; then
+            echo "::notice::acumatica-test is already stopped"
+          else
+            echo "::warning::acumatica-test is in unexpected state: $STATUS"
+          fi


### PR DESCRIPTION
## Summary
- Updated vm-autostart cron from 8 AM ET weekdays to 10 AM CT daily
- Added vm-autostop workflow at midnight CT daily
- Saves compute costs overnight while covering deploy window

🤖 Generated with [Claude Code](https://claude.com/claude-code)