### PR TITLE
fix(pipeline): drop --no-merge and --pre-cleanup workarounds

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -963,12 +963,10 @@ jobs:
 
           # Sandbox uses only managed code — no ISV packages.
           # Read sandbox co-publish list from acuops.yaml (same as old test tenant list).
-          # --no-merge: sandbox AND prod have orphaned CustProject rows for
-          # IIGCONTAINERMGMT[24.204.0004][R19]1, IIGHFContainerMods[24.204.0004][R04],
-          # and AesthetikContainerGIs. merge=true triggers "An error has occurred"
-          # on publishBegin. VAR support ticket pending at
-          # docs/acumatica-support-ticket-iig-orphan.md — drop --no-merge once
-          # Acumatica engineering cleans the three ghost rows.
+          # Orphan CustProject rows (IIGCONTAINERMGMT, IIGHFContainerMods,
+          # AesthetikContainerGIs) that blocked merge=true were cleaned 2026-04-15.
+          # --no-merge and --pre-cleanup are no longer needed and cause GI OData
+          # de-registration + circuit-breaker trips. See memory/context/gi-odata-deploy-fix.md.
           SANDBOX_ALSO=$(python3 -c "
           import yaml
           with open('acuops.yaml') as f:
@@ -980,9 +978,7 @@ jobs:
             --project "${PROJECT}" \
             --package "${PACKAGE_FILE}" \
             --also-publish "${SANDBOX_ALSO}" \
-            --no-merge \
             --skip-smoke-test \
-            --pre-cleanup \
             ${EXTRA_FLAGS}
 
       - name: Verify sandbox
@@ -2284,7 +2280,6 @@ jobs:
             --project "${PROJECT}" \
             --package "${PACKAGE_FILE}" \
             --also-publish "${STG_COPUBLISH}" \
-            --pre-cleanup \
             ${EXTRA_FLAGS}
 
       - name: Verify staging publish

--- a/acuops.yaml
+++ b/acuops.yaml
@@ -64,10 +64,8 @@ pipeline:
   also_publish_test:
     # AesthetikContainerGIs deleted 2026-04-09 — every GI/SiteMap entry was
     # a verbatim duplicate of what AesthetikContainers already ships (same
-    # DesignIDs). PR #211 added it as a level-4 package to work around a
-    # compile-ordering concern that turned out to not be real. The orphan
-    # CustProject row on both sandbox and production still needs cleanup via
-    # the Acumatica support ticket (docs/acumatica-support-ticket-iig-orphan.md).
+    # DesignIDs). Orphan CustProject row cleaned up 2026-04-15 via
+    # /CustomizationApi/delete (no support ticket needed).
     - "AesthetikWMS"
     - "StudioBAcuOps"
   test_tenant_enabled: true


### PR DESCRIPTION
## Summary
Orphan CustProject rows are gone. The workarounds they necessitated can now be removed.

- Sandbox deploy: drop `--no-merge` + `--pre-cleanup`
- Staging deploy: drop `--pre-cleanup`
- Update comments in workflow + acuops.yaml

Prod deploy step already cleaned up in PR #413.

## Validation
Empty-list `publishBegin` with `merge=true` on prod completes successfully:
- `isCompleted: true, isFailed: false`
- "Validation finished successfully."

Full-project (AesthetikContainers + AesthetikWMS + StudioBAcuOps) `merge=true` validation also completes cleanly (tested at 15:30 UTC).

## Side effects of this change
- ✅ GI OData re-registration now survives deploys (no manual SM208000 toggling)
- ✅ ASPX files for co-published projects deploy correctly
- ✅ `--pre-cleanup` NullReferenceException trips go away
- ⚠️ First deploy after merge: existing GI screen access for api-bot may need re-granting via SM208000 "Publish for all users" (see PR for RolesInGraph fix)

## Do not merge until
- ✅ Current CI/CD state verified stable on main (Import endpoint confirmed working)
- ✅ Paired with RolesInGraph fix PR (prevents access regression on next publish)
- ⏳ After 6pm CT (publish = app pool restart)

## Rollback
Single commit revert if anything unexpected surfaces on first merge=true deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)