### PR TITLE
fix(gi): add RolesInGraph to DRP GI SiteMap rows for stable access

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -2181,6 +2181,8 @@ public partial class Page_SB_SB302040 : PXPage
           <SiteMap linkname="toDesignById">
             <row Position="1160" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=1ce25f0a-cde6-4f0a-b939-d274fe343574" Expanded="0" IsFolder="0" ScreenID="SB401080" NodeID="aed2bb14-04d3-4715-ba57-6bd405423270" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2070" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
+              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
+              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
             </row>
           </SiteMap>
 
@@ -2352,6 +2354,8 @@ public partial class Page_SB_SB302040 : PXPage
           <SiteMap linkname="toDesignById">
             <row Position="1170" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=f918a504-7620-461c-aad8-f1b3395d1e79" Expanded="0" IsFolder="0" ScreenID="SB401090" NodeID="af758f49-f888-4d32-b162-838a5fa34c52" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2080" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
+              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
+              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
             </row>
           </SiteMap>
 
@@ -2519,6 +2523,8 @@ public partial class Page_SB_SB302040 : PXPage
           <SiteMap linkname="toDesignById">
             <row Position="1180" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=a5337a02-6d79-42e9-b400-d7178ac3fd24" Expanded="0" IsFolder="0" ScreenID="SB401110" NodeID="1fb65d0f-ebc6-4ec5-8e19-5c5022245ff5" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2090" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
+              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
+              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
             </row>
           </SiteMap>
 
@@ -2702,6 +2708,8 @@ public partial class Page_SB_SB302040 : PXPage
           <SiteMap linkname="toDesignById">
             <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="660b0c64-b2bf-4848-a863-468f5ff34fbd" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
+              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
+              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
             </row>
           </SiteMap>
 
@@ -2746,6 +2754,8 @@ public partial class Page_SB_SB302040 : PXPage
           <SiteMap linkname="toDesignById">
             <row Position="1190" Title="DRP Item Warehouse Settings" Url="~/GenericInquiry/GenericInquiry.aspx?id=6e77b05f-ef4d-49e7-90ac-4c703006880d" Expanded="0" IsFolder="0" ScreenID="SB401120" NodeID="3e124ece-6462-4be9-acc7-6372d6da32ef" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
+              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
+              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
             </row>
           </SiteMap>
 

--- a/scripts/build_drp_a3_gi.py
+++ b/scripts/build_drp_a3_gi.py
@@ -134,6 +134,8 @@ A3_GIDESIGN = f'''        <row DesignID="{A3_DESIGN}" Name="DRP_OpenPOLines" Scr
           <SiteMap linkname="toDesignById">
             <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id={A3_DESIGN}" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="{A3_NODE}" ParentID="{PARENT_ID}">
               <MUIScreen IsPortal="0" WorkspaceID="{WORKSPACE_ID}" Order="2100" SubcategoryID="{SUBCAT_ID}" />
+              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
+              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
             </row>
           </SiteMap>
 

--- a/scripts/build_drp_item_warehouse_gi.py
+++ b/scripts/build_drp_item_warehouse_gi.py
@@ -70,6 +70,8 @@ def sitemap_row(position, title, design_id, screen_id, node_id, order_num):
             f'NodeID="{node_id}" ParentID="{PARENT_ID}">\n'
             f'              <MUIScreen IsPortal="0" WorkspaceID="{WORKSPACE_ID}" '
             f'Order="{order_num}" SubcategoryID="{SUBCAT_ID}" />\n'
+            f'              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />\n'
+            f'              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />\n'
             f'            </row>\n'
             f'          </SiteMap>')
 

--- a/scripts/build_drp_phase0_gis.py
+++ b/scripts/build_drp_phase0_gis.py
@@ -90,6 +90,8 @@ def sitemap_row(position, title, design_id, screen_id, node_id, order_num):
             f'NodeID="{node_id}" ParentID="{PARENT_ID}">\n'
             f'              <MUIScreen IsPortal="0" WorkspaceID="{WORKSPACE_ID}" '
             f'Order="{order_num}" SubcategoryID="{SUBCAT_ID}" />\n'
+            f'              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />\n'
+            f'              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />\n'
             f'            </row>\n'
             f'          </SiteMap>')
 


### PR DESCRIPTION
## Summary
Adds `<RolesInGraph Rolename="Administrator"/>` + `<RolesInGraph Rolename="*"/>` to each of the 5 DRP GI SiteMap rows so screen access for api-bot (and every user role) survives future deploys.

Stops the pattern where every publish required manual SM208000 "Publish for all users" toggling.

## Affected GIs

| GI | Screen ID |
|---|---|
| DRP_VelocityHistory | SB401080 |
| DRP_OpenSOCommitments | SB401090 |
| DRP_InventoryBySite | SB401110 |
| DRP_OpenPOLines | SB401100 |
| DRP_ItemWarehouseSettings | SB401120 |

## Why this works
The SM208000 "Publish to the UI" dialog's "Set to Granted for All Roles" radio button creates Roles-in-Graph rows in Acumatica's access tables for every role. `<RolesInGraph Rolename="*" Accessrights="4"/>` in the customization XML does the same at publish time — survives every reimport.

Pattern already used by other customizations in this repo (Container Tracking pages SB501000, SB302000, SB302010, etc).

## Build script updates
Also patches the 3 Python GI build scripts to emit `<RolesInGraph>` so future regenerations stay consistent:
- `scripts/build_drp_phase0_gis.py`
- `scripts/build_drp_a3_gi.py`
- `scripts/build_drp_item_warehouse_gi.py`

## Depends on
- [PR for --no-merge removal](https://github.com/studio-b-ai/acumatica-ci-cd/pull/416)

Without `merge=true`, SiteMap reimport semantics differ and this fix may not fully take effect on first deploy. Merge order: #416 first, then this.

## Do not merge until
- ⏳ After 6pm CT (publish = app pool restart)
- ✅ Paired with #416 merged first

🤖 Generated with [Claude Code](https://claude.com/claude-code)