### PR TITLE
fix: replace DRP GI XML definitions with SQL installers for OData access

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -24,20 +24,416 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
   ALTER TABLE POOrder ADD UsrFactoryReadyDate datetime NULL;
 ]]></CDATA>
     </Sql>
-    <Sql Name="AesthetikContainers_EnableOData_v1" Script="#CDATA">
-        <CDATA name="Script"><![CDATA[-- Enable OData exposure for DRP Generic Inquiries after publish.
--- The import engine sets ExposeViaOData from XML, but subsequent publishes
--- can reset it. This SQL ensures it stays enabled.
--- DesignIDs are fixed GUIDs from build_drp_phase0_gis.py.
-UPDATE GIDesign SET ExposeViaOData = 1
-WHERE DesignID IN (
-  '1ce25f0a-cde6-4f0a-b939-d274fe343574',  -- DRP_VelocityHistory
-  'f918a504-7620-461c-aad8-f1b3395d1e79',  -- DRP_OpenSOCommitments
-  'a5337a02-6d79-42e9-b400-d7178ac3fd24',  -- DRP_InventoryBySite
-  '89912975-c6ed-41ad-b514-a0f775a89362'   -- DRP_OpenPOLines
-  ,'6e77b05f-ef4d-49e7-90ac-4c703006880d'  -- DRP_ItemWarehouseSettings
-)
-AND ExposeViaOData = 0;
+    <Sql Name="InstallDRP_VelocityHistoryGI" Script="#CDATA">
+        <CDATA name="Script"><![CDATA[-- REVIEWED: gi-sql-safe
+-- DRP_VelocityHistory GI installer — shipped lines with dates for velocity analysis.
+-- SQL-installed with NO ScreenID so OData works without SiteMap access checks.
+-- Upsert pattern: delete existing, insert fresh.
+
+DECLARE @CompanyID int = 2;
+DECLARE @DesignID uniqueidentifier;
+DECLARE @Now datetime = GETUTCDATE();
+
+-- Discover CompanyID from a known GI
+SELECT TOP 1 @CompanyID = CompanyID FROM GIDesign WHERE Name = 'InventoryAllocationDetail';
+
+-- Clean up existing GI (for re-deploy idempotency)
+SELECT @DesignID = DesignID FROM GIDesign WHERE Name = 'DRP_VelocityHistory' AND CompanyID = @CompanyID;
+IF @DesignID IS NOT NULL
+BEGIN
+    DELETE FROM GIFilter   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GISort     WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIResult   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIGroupBy  WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIOn       WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIRelation WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIWhere    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GITable    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIDesign   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+END
+
+SET @DesignID = NEWID();
+
+-- GI header (ExposeViaOData=1, NO ScreenID — avoids SiteMap access check)
+INSERT INTO GIDesign (CompanyID, DesignID, Name, Description, ExposeViaOData, CreatedDateTime, LastModifiedDateTime)
+VALUES (@CompanyID, @DesignID, 'DRP_VelocityHistory', 'DRP — shipped lines with ship date, customer, site for velocity analysis', 1, @Now, @Now);
+
+-- Tables
+INSERT INTO GITable (CompanyID, DesignID, Alias, Name, IsActive)
+VALUES
+    (@CompanyID, @DesignID, 'SOShipLine', 'PX.Objects.SO.SOShipLine', 1),
+    (@CompanyID, @DesignID, 'SOShipment', 'PX.Objects.SO.SOShipment', 1),
+    (@CompanyID, @DesignID, 'SOLine', 'PX.Objects.SO.SOLine', 1);
+
+-- Relation 1: SOShipLine → SOShipment (LEFT on ShipmentNbr)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 1, 'SOShipLine', 'SOShipment', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES (@CompanyID, @DesignID, 1, 1, 'ShipmentNbr', 'ShipmentNbr', 'E ', 'A');
+
+-- Relation 2: SOShipLine → SOLine (LEFT on OrigOrderType/OrigOrderNbr/OrigLineNbr)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 2, 'SOShipLine', 'SOLine', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES
+    (@CompanyID, @DesignID, 2, 1, 'OrigOrderType', 'OrderType', 'E ', 'A'),
+    (@CompanyID, @DesignID, 2, 2, 'OrigOrderNbr', 'OrderNbr', 'E ', 'A'),
+    (@CompanyID, @DesignID, 2, 3, 'OrigLineNbr', 'LineNbr', 'E ', 'A');
+
+-- Result columns (8)
+INSERT INTO GIResult (CompanyID, DesignID, LineNbr, ObjectName, Field, IsVisible, SortOrder)
+VALUES
+    (@CompanyID, @DesignID, 1, 'SOShipLine', 'InventoryID', 1, 1),
+    (@CompanyID, @DesignID, 2, 'SOShipLine', 'ShippedQty', 1, 2),
+    (@CompanyID, @DesignID, 3, 'SOShipLine', 'OrigOrderType', 1, 3),
+    (@CompanyID, @DesignID, 4, 'SOShipLine', 'OrigOrderNbr', 1, 4),
+    (@CompanyID, @DesignID, 5, 'SOShipLine', 'SiteID', 1, 5),
+    (@CompanyID, @DesignID, 6, 'SOShipLine', 'UOM', 1, 6),
+    (@CompanyID, @DesignID, 7, 'SOShipment', 'ShipDate', 1, 7),
+    (@CompanyID, @DesignID, 8, 'SOLine', 'CustomerID', 1, 8);
+
+-- Where: Confirmed shipments, Issue operation only
+INSERT INTO GIWhere (CompanyID, DesignID, LineNbr, IsActive, DataFieldName, Condition, IsExpression, Value1, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 1, 'SOShipment.Confirmed', 'E ', 0, 'True', 'A'),
+    (@CompanyID, @DesignID, 2, 1, 'SOShipment.Operation', 'E ', 0, 'I', 'A');
+
+-- Sort: ShipDate descending
+INSERT INTO GISort (CompanyID, DesignID, LineNbr, DataFieldName, IsDescending)
+VALUES (@CompanyID, @DesignID, 1, 'SOShipment.ShipDate', 1);
+]]></CDATA>
+    </Sql>
+    <Sql Name="InstallDRP_OpenSOCommitmentsGI" Script="#CDATA">
+        <CDATA name="Script"><![CDATA[-- REVIEWED: gi-sql-safe
+-- DRP_OpenSOCommitments GI installer — open SO lines for demand planning.
+-- SQL-installed with NO ScreenID so OData works without SiteMap access checks.
+-- Upsert pattern: delete existing, insert fresh.
+
+DECLARE @CompanyID int = 2;
+DECLARE @DesignID uniqueidentifier;
+DECLARE @Now datetime = GETUTCDATE();
+
+SELECT TOP 1 @CompanyID = CompanyID FROM GIDesign WHERE Name = 'InventoryAllocationDetail';
+
+SELECT @DesignID = DesignID FROM GIDesign WHERE Name = 'DRP_OpenSOCommitments' AND CompanyID = @CompanyID;
+IF @DesignID IS NOT NULL
+BEGIN
+    DELETE FROM GIFilter   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GISort     WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIResult   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIGroupBy  WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIOn       WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIRelation WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIWhere    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GITable    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIDesign   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+END
+
+SET @DesignID = NEWID();
+
+INSERT INTO GIDesign (CompanyID, DesignID, Name, Description, ExposeViaOData, CreatedDateTime, LastModifiedDateTime)
+VALUES (@CompanyID, @DesignID, 'DRP_OpenSOCommitments', 'DRP — open SO lines (CO/SO/PC) for demand commitment tracking', 1, @Now, @Now);
+
+INSERT INTO GITable (CompanyID, DesignID, Alias, Name, IsActive)
+VALUES
+    (@CompanyID, @DesignID, 'SOOrder', 'PX.Objects.SO.SOOrder', 1),
+    (@CompanyID, @DesignID, 'SOLine', 'PX.Objects.SO.SOLine', 1);
+
+-- Relation 1: SOOrder → SOLine (INNER on OrderType/OrderNbr)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 1, 'SOOrder', 'SOLine', 1, 'I');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 1, 'OrderType', 'OrderType', 'E ', 'A'),
+    (@CompanyID, @DesignID, 1, 2, 'OrderNbr', 'OrderNbr', 'E ', 'A');
+
+-- Result columns (11)
+INSERT INTO GIResult (CompanyID, DesignID, LineNbr, ObjectName, Field, IsVisible, SortOrder)
+VALUES
+    (@CompanyID, @DesignID, 1, 'SOLine', 'InventoryID', 1, 1),
+    (@CompanyID, @DesignID, 2, 'SOLine', 'OrderType', 1, 2),
+    (@CompanyID, @DesignID, 3, 'SOLine', 'OrderNbr', 1, 3),
+    (@CompanyID, @DesignID, 4, 'SOLine', 'LineNbr', 1, 4),
+    (@CompanyID, @DesignID, 5, 'SOLine', 'OrderQty', 1, 5),
+    (@CompanyID, @DesignID, 6, 'SOLine', 'ShippedQty', 1, 6),
+    (@CompanyID, @DesignID, 7, 'SOLine', 'OpenQty', 1, 7),
+    (@CompanyID, @DesignID, 8, 'SOLine', 'RequestDate', 1, 8),
+    (@CompanyID, @DesignID, 9, 'SOOrder', 'CustomerID', 1, 9),
+    (@CompanyID, @DesignID, 10, 'SOLine', 'SiteID', 1, 10),
+    (@CompanyID, @DesignID, 11, 'SOLine', 'UOM', 1, 11);
+
+-- Where: Goods-for-Issue lines, open qty > 0, order types CO/SO/PC
+INSERT INTO GIWhere (CompanyID, DesignID, LineNbr, OpenBrackets, CloseBrackets, IsActive, DataFieldName, Condition, IsExpression, Value1, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 0, 0, 1, 'SOLine.LineType', 'E ', 0, 'GI', 'A'),
+    (@CompanyID, @DesignID, 2, 0, 0, 1, 'SOLine.OpenQty', 'G ', 0, '0', 'A'),
+    (@CompanyID, @DesignID, 3, 1, 0, 1, 'SOLine.OrderType', 'E ', 0, 'CO', 'O'),
+    (@CompanyID, @DesignID, 4, 0, 0, 1, 'SOLine.OrderType', 'E ', 0, 'SO', 'O'),
+    (@CompanyID, @DesignID, 5, 0, 1, 1, 'SOLine.OrderType', 'E ', 0, 'PC', 'A');
+
+-- Sort: RequestDate ascending
+INSERT INTO GISort (CompanyID, DesignID, LineNbr, DataFieldName, IsDescending)
+VALUES (@CompanyID, @DesignID, 1, 'SOLine.RequestDate', 0);
+]]></CDATA>
+    </Sql>
+    <Sql Name="InstallDRP_InventoryBySiteGI" Script="#CDATA">
+        <CDATA name="Script"><![CDATA[-- REVIEWED: gi-sql-safe
+-- DRP_InventoryBySite GI installer — stock item quantities per warehouse.
+-- SQL-installed with NO ScreenID so OData works without SiteMap access checks.
+-- Upsert pattern: delete existing, insert fresh.
+
+DECLARE @CompanyID int = 2;
+DECLARE @DesignID uniqueidentifier;
+DECLARE @Now datetime = GETUTCDATE();
+
+SELECT TOP 1 @CompanyID = CompanyID FROM GIDesign WHERE Name = 'InventoryAllocationDetail';
+
+SELECT @DesignID = DesignID FROM GIDesign WHERE Name = 'DRP_InventoryBySite' AND CompanyID = @CompanyID;
+IF @DesignID IS NOT NULL
+BEGIN
+    DELETE FROM GIFilter   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GISort     WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIResult   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIGroupBy  WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIOn       WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIRelation WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIWhere    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GITable    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIDesign   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+END
+
+SET @DesignID = NEWID();
+
+INSERT INTO GIDesign (CompanyID, DesignID, Name, Description, ExposeViaOData, CreatedDateTime, LastModifiedDateTime)
+VALUES (@CompanyID, @DesignID, 'DRP_InventoryBySite', 'DRP — active/non-saleable stock item quantities per warehouse', 1, @Now, @Now);
+
+INSERT INTO GITable (CompanyID, DesignID, Alias, Name, IsActive)
+VALUES
+    (@CompanyID, @DesignID, 'InventoryItem', 'PX.Objects.IN.InventoryItem', 1),
+    (@CompanyID, @DesignID, 'INSiteStatus', 'PX.Objects.IN.INSiteStatus', 1);
+
+-- Relation 1: InventoryItem → INSiteStatus (INNER on InventoryID)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 1, 'InventoryItem', 'INSiteStatus', 1, 'I');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES (@CompanyID, @DesignID, 1, 1, 'InventoryID', 'InventoryID', 'E ', 'A');
+
+-- Result columns (9)
+INSERT INTO GIResult (CompanyID, DesignID, LineNbr, ObjectName, Field, IsVisible, SortOrder)
+VALUES
+    (@CompanyID, @DesignID, 1, 'InventoryItem', 'InventoryCD', 1, 1),
+    (@CompanyID, @DesignID, 2, 'InventoryItem', 'Descr', 1, 2),
+    (@CompanyID, @DesignID, 3, 'InventoryItem', 'ItemStatus', 1, 3),
+    (@CompanyID, @DesignID, 4, 'InventoryItem', 'ItemClassID', 1, 4),
+    (@CompanyID, @DesignID, 5, 'INSiteStatus', 'SiteID', 1, 5),
+    (@CompanyID, @DesignID, 6, 'INSiteStatus', 'QtyOnHand', 1, 6),
+    (@CompanyID, @DesignID, 7, 'INSiteStatus', 'QtyAvail', 1, 7),
+    (@CompanyID, @DesignID, 8, 'INSiteStatus', 'QtyHardAvail', 1, 8),
+    (@CompanyID, @DesignID, 9, 'INSiteStatus', 'QtyAllocated', 1, 9);
+
+-- Where: Stock items only, Active or Non-Saleable status
+INSERT INTO GIWhere (CompanyID, DesignID, LineNbr, OpenBrackets, CloseBrackets, IsActive, DataFieldName, Condition, IsExpression, Value1, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 0, 0, 1, 'InventoryItem.StkItem', 'E ', 0, 'True', 'A'),
+    (@CompanyID, @DesignID, 2, 1, 0, 1, 'InventoryItem.ItemStatus', 'E ', 0, 'AC', 'O'),
+    (@CompanyID, @DesignID, 3, 0, 1, 1, 'InventoryItem.ItemStatus', 'E ', 0, 'NS', 'A');
+
+-- Sort: InventoryCD then SiteID ascending
+INSERT INTO GISort (CompanyID, DesignID, LineNbr, DataFieldName, IsDescending)
+VALUES
+    (@CompanyID, @DesignID, 1, 'InventoryItem.InventoryCD', 0),
+    (@CompanyID, @DesignID, 2, 'INSiteStatus.SiteID', 0);
+]]></CDATA>
+    </Sql>
+    <Sql Name="InstallDRP_OpenPOLinesGI" Script="#CDATA">
+        <CDATA name="Script"><![CDATA[-- REVIEWED: gi-sql-safe
+-- DRP_OpenPOLines GI installer — open PO lines with container linkage.
+-- SQL-installed with NO ScreenID so OData works without SiteMap access checks.
+-- Upsert pattern: delete existing, insert fresh.
+
+DECLARE @CompanyID int = 2;
+DECLARE @DesignID uniqueidentifier;
+DECLARE @Now datetime = GETUTCDATE();
+
+SELECT TOP 1 @CompanyID = CompanyID FROM GIDesign WHERE Name = 'InventoryAllocationDetail';
+
+SELECT @DesignID = DesignID FROM GIDesign WHERE Name = 'DRP_OpenPOLines' AND CompanyID = @CompanyID;
+IF @DesignID IS NOT NULL
+BEGIN
+    DELETE FROM GIFilter   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GISort     WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIResult   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIGroupBy  WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIOn       WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIRelation WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIWhere    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GITable    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIDesign   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+END
+
+SET @DesignID = NEWID();
+
+INSERT INTO GIDesign (CompanyID, DesignID, Name, Description, ExposeViaOData, CreatedDateTime, LastModifiedDateTime)
+VALUES (@CompanyID, @DesignID, 'DRP_OpenPOLines', 'DRP — open PO lines with vendor lead-time dates and container linkage', 1, @Now, @Now);
+
+-- Tables: POOrder (primary), Line (POLine), ContainerLink (UsrContainerPOLink), Container (UsrContainer)
+INSERT INTO GITable (CompanyID, DesignID, Alias, Name, IsActive)
+VALUES
+    (@CompanyID, @DesignID, 'POOrder', 'PX.Objects.PO.POOrder', 1),
+    (@CompanyID, @DesignID, 'Line', 'PX.Objects.PO.POLine', 1),
+    (@CompanyID, @DesignID, 'ContainerLink', 'StudioB.Containers.UsrContainerPOLink', 1),
+    (@CompanyID, @DesignID, 'Container', 'StudioB.Containers.UsrContainer', 1);
+
+-- Relation 1: POOrder → Line (INNER on OrderType/OrderNbr)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 1, 'POOrder', 'Line', 1, 'I');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 1, 'OrderType', 'OrderType', 'E ', 'A'),
+    (@CompanyID, @DesignID, 1, 2, 'OrderNbr', 'OrderNbr', 'E ', 'A');
+
+-- Relation 2: Line → ContainerLink (LEFT on OrderType/OrderNbr/LineNbr)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 2, 'Line', 'ContainerLink', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES
+    (@CompanyID, @DesignID, 2, 1, 'OrderType', 'OrderType', 'E ', 'A'),
+    (@CompanyID, @DesignID, 2, 2, 'OrderNbr', 'OrderNbr', 'E ', 'A'),
+    (@CompanyID, @DesignID, 2, 3, 'LineNbr', 'LineNbr', 'E ', 'A');
+
+-- Relation 3: ContainerLink → Container (LEFT on ContainerID)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 3, 'ContainerLink', 'Container', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES (@CompanyID, @DesignID, 3, 1, 'ContainerID', 'ContainerID', 'E ', 'A');
+
+-- Result columns (12)
+INSERT INTO GIResult (CompanyID, DesignID, LineNbr, ObjectName, Field, IsVisible, SortOrder)
+VALUES
+    (@CompanyID, @DesignID, 1, 'Line', 'OrderType', 1, 1),
+    (@CompanyID, @DesignID, 2, 'Line', 'OrderNbr', 1, 2),
+    (@CompanyID, @DesignID, 3, 'Line', 'LineNbr', 1, 3),
+    (@CompanyID, @DesignID, 4, 'Line', 'InventoryID', 1, 4),
+    (@CompanyID, @DesignID, 5, 'Line', 'VendorID', 1, 5),
+    (@CompanyID, @DesignID, 6, 'Line', 'OrderQty', 1, 6),
+    (@CompanyID, @DesignID, 7, 'Line', 'ReceivedQty', 1, 7),
+    (@CompanyID, @DesignID, 8, 'Line', 'OpenQty', 1, 8),
+    (@CompanyID, @DesignID, 9, 'Line', 'PromisedDate', 1, 9),
+    (@CompanyID, @DesignID, 10, 'POOrder', 'UsrAcknowledgedDate', 1, 10),
+    (@CompanyID, @DesignID, 11, 'POOrder', 'UsrFactoryReadyDate', 1, 11),
+    (@CompanyID, @DesignID, 12, 'Container', 'ContainerCD', 1, 12);
+
+-- Where: Goods-for-Issue lines, open qty > 0, PO status New or Open
+INSERT INTO GIWhere (CompanyID, DesignID, LineNbr, OpenBrackets, CloseBrackets, IsActive, DataFieldName, Condition, IsExpression, Value1, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 0, 0, 1, 'Line.LineType', 'E ', 0, 'GI', 'A'),
+    (@CompanyID, @DesignID, 2, 0, 0, 1, 'Line.OpenQty', 'G ', 0, '0', 'A'),
+    (@CompanyID, @DesignID, 3, 1, 0, 1, 'POOrder.Status', 'E ', 0, 'N', 'O'),
+    (@CompanyID, @DesignID, 4, 0, 1, 1, 'POOrder.Status', 'E ', 0, 'O', 'A');
+
+-- Sort: PromisedDate ascending
+INSERT INTO GISort (CompanyID, DesignID, LineNbr, DataFieldName, IsDescending)
+VALUES (@CompanyID, @DesignID, 1, 'Line.PromisedDate', 0);
+]]></CDATA>
+    </Sql>
+    <Sql Name="InstallDRP_ItemWarehouseSettingsGI" Script="#CDATA">
+        <CDATA name="Script"><![CDATA[-- REVIEWED: gi-sql-safe
+-- DRP_ItemWarehouseSettings GI installer — replenishment settings per item/warehouse.
+-- SQL-installed with NO ScreenID so OData works without SiteMap access checks.
+-- Upsert pattern: delete existing, insert fresh.
+
+DECLARE @CompanyID int = 2;
+DECLARE @DesignID uniqueidentifier;
+DECLARE @Now datetime = GETUTCDATE();
+
+SELECT TOP 1 @CompanyID = CompanyID FROM GIDesign WHERE Name = 'InventoryAllocationDetail';
+
+SELECT @DesignID = DesignID FROM GIDesign WHERE Name = 'DRP_ItemWarehouseSettings' AND CompanyID = @CompanyID;
+IF @DesignID IS NOT NULL
+BEGIN
+    DELETE FROM GIFilter   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GISort     WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIResult   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIGroupBy  WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIOn       WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIRelation WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIWhere    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GITable    WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+    DELETE FROM GIDesign   WHERE DesignID = @DesignID AND CompanyID = @CompanyID;
+END
+
+SET @DesignID = NEWID();
+
+INSERT INTO GIDesign (CompanyID, DesignID, Name, Description, ExposeViaOData, CreatedDateTime, LastModifiedDateTime)
+VALUES (@CompanyID, @DesignID, 'DRP_ItemWarehouseSettings', 'DRP — item/warehouse replenishment settings with vendor lead times', 1, @Now, @Now);
+
+-- Tables: INItemSite (primary), InventoryItem, INSite, POVendorInventory
+INSERT INTO GITable (CompanyID, DesignID, Alias, Name, IsActive)
+VALUES
+    (@CompanyID, @DesignID, 'INItemSite', 'PX.Objects.IN.INItemSite', 1),
+    (@CompanyID, @DesignID, 'InventoryItem', 'PX.Objects.IN.InventoryItem', 1),
+    (@CompanyID, @DesignID, 'INSite', 'PX.Objects.IN.INSite', 1),
+    (@CompanyID, @DesignID, 'POVendorInventory', 'PX.Objects.PO.POVendorInventory', 1);
+
+-- Relation 1: INItemSite → InventoryItem (LEFT on InventoryID)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 1, 'INItemSite', 'InventoryItem', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES (@CompanyID, @DesignID, 1, 1, 'InventoryID', 'InventoryID', 'E ', 'A');
+
+-- Relation 2: INItemSite → INSite (LEFT on SiteID)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 2, 'INItemSite', 'INSite', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES (@CompanyID, @DesignID, 2, 1, 'SiteID', 'SiteID', 'E ', 'A');
+
+-- Relation 3: INItemSite → POVendorInventory (LEFT on InventoryID + PreferredVendorID)
+INSERT INTO GIRelation (CompanyID, DesignID, LineNbr, ParentTable, ChildTable, IsActive, JoinType)
+VALUES (@CompanyID, @DesignID, 3, 'INItemSite', 'POVendorInventory', 1, 'L');
+
+INSERT INTO GIOn (CompanyID, DesignID, RelationNbr, LineNbr, ParentField, ChildField, Condition, Operation)
+VALUES
+    (@CompanyID, @DesignID, 3, 1, 'InventoryID', 'InventoryID', 'E ', 'A'),
+    (@CompanyID, @DesignID, 3, 2, 'PreferredVendorID', 'VendorID', 'E ', 'A');
+
+-- Result columns (13)
+INSERT INTO GIResult (CompanyID, DesignID, LineNbr, ObjectName, Field, IsVisible, SortOrder)
+VALUES
+    (@CompanyID, @DesignID, 1, 'InventoryItem', 'InventoryCD', 1, 1),
+    (@CompanyID, @DesignID, 2, 'INSite', 'SiteCD', 1, 2),
+    (@CompanyID, @DesignID, 3, 'InventoryItem', 'BaseUnit', 1, 3),
+    (@CompanyID, @DesignID, 4, 'INItemSite', 'SafetyStock', 1, 4),
+    (@CompanyID, @DesignID, 5, 'INItemSite', 'MinQty', 1, 5),
+    (@CompanyID, @DesignID, 6, 'INItemSite', 'MaxQty', 1, 6),
+    (@CompanyID, @DesignID, 7, 'INItemSite', 'MinOrdQty', 1, 7),
+    (@CompanyID, @DesignID, 8, 'INItemSite', 'ReplenishmentSource', 1, 8),
+    (@CompanyID, @DesignID, 9, 'INItemSite', 'ReplenishmentPolicyOverride', 1, 9),
+    (@CompanyID, @DesignID, 10, 'INItemSite', 'PreferredVendorID', 1, 10),
+    (@CompanyID, @DesignID, 11, 'POVendorInventory', 'VLeadTime', 1, 11),
+    (@CompanyID, @DesignID, 12, 'INItemSite', 'ABCCodeID', 1, 12),
+    (@CompanyID, @DesignID, 13, 'POVendorInventory', 'AddLeadTimeDays', 1, 13);
+
+-- Where: Stock items only, Active or Non-Saleable status
+INSERT INTO GIWhere (CompanyID, DesignID, LineNbr, OpenBrackets, CloseBrackets, IsActive, DataFieldName, Condition, IsExpression, Value1, Operation)
+VALUES
+    (@CompanyID, @DesignID, 1, 0, 0, 1, 'InventoryItem.StkItem', 'E ', 0, 'True', 'A'),
+    (@CompanyID, @DesignID, 2, 1, 0, 1, 'InventoryItem.ItemStatus', 'E ', 0, 'AC', 'O'),
+    (@CompanyID, @DesignID, 3, 0, 1, 1, 'InventoryItem.ItemStatus', 'E ', 0, 'NS', 'A');
+
+-- Sort: InventoryCD then SiteCD ascending
+INSERT INTO GISort (CompanyID, DesignID, LineNbr, DataFieldName, IsDescending)
+VALUES
+    (@CompanyID, @DesignID, 1, 'InventoryItem.InventoryCD', 0),
+    (@CompanyID, @DesignID, 2, 'INSite.SiteCD', 0);
 ]]></CDATA>
     </Sql>
     <%-- AesthetikContainers_SchemaDiscovery_v1 removed — diagnostic only, not needed in CI --%>
@@ -2019,752 +2415,6 @@ public partial class Page_SB_SB302040 : PXPage
     </data>
   </data-set>
 </GenericInquiryScreen>
-    <GenericInquiryScreen>
-  <data-set>
-                <relations format-version="3" relations-version="20240201" main-table="GIDesign" stable-sharing="True" file-name="(Name)">
-    <link from="GIFilter (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIGroupBy (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassAction (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassUpdateField (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationScreen (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationParameter (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GINavigationCondition (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GIOn (DesignID, RelationNbr)" to="GIRelation (DesignID, LineNbr)" />
-    <link from="GIRecordDefault (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIRelation (DesignID, ParentTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIRelation (DesignID, ChildTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIResult (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIResult (ObjectName, DesignID)" to="GITable (Alias, DesignID)" />
-    <link from="GISort (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GITable (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIWhere (DesignID)" to="GIDesign (DesignID)" />
-    <link from="SiteMap (Url)" to="GIDesign (DesignID)" type="WeakByUrl" linkname="toDesignById" baseurl="~/GenericInquiry/GenericInquiry.aspx" paramnames="id" />
-    <link from="SiteMap (Url)" to="GIDesign (Name)" type="WeakByUrl" linkname="toDesignByName" baseurl="~/GenericInquiry/GenericInquiry.aspx" />
-    <link from="ListEntryPoint (ListScreenID)" to="SiteMap (ScreenID)" />
-    <link from="SiteMap (ScreenID)" to="GIDesign (PrimaryScreenIDNew)" linkname="to1Screen" />
-    <link from="FilterHeader (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="FilterRow (FilterID)" to="FilterHeader (FilterID)" />
-    <link from="PivotTable (NoteID)" to="FilterHeader (RefNoteID)" />
-    <link from="PivotField (ScreenID, PivotTableID)" to="PivotTable (ScreenID, PivotTableID)" />
-    <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
-    <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
-    <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
-    <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
-    <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="GIDesign (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="GIFilterKvExt (RecordID)" type="RowKvExt" />
-    <link from="GIGroupBy (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIOn (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIRelation (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="GIResultKvExt (RecordID)" type="RowKvExt" />
-    <link from="GISort (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GITable (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIWhere (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="FilterHeaderKvExt (RecordID)" type="RowKvExt" />
-</relations>
-            <layout>
-    <table name="GIDesign">
-        <table name="GIFilter" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-            <table name="GIFilterKvExt" uplink="(NoteID) = (RecordID)" />
-        </table>
-        <table name="GIGroupBy" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIMassAction" uplink="(DesignID) = (DesignID)" />
-        <table name="GIMassUpdateField" uplink="(DesignID) = (DesignID)" />
-        <table name="GINavigationScreen" uplink="(DesignID) = (DesignID)">
-            <table name="GINavigationParameter" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-            <table name="GINavigationCondition" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-        </table>
-        <table name="GIRecordDefault" uplink="(DesignID) = (DesignID)" />
-        <table name="GISort" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GITable" uplink="(DesignID) = (DesignID)">
-            <table name="GIRelation" uplink="(DesignID, Alias) = (DesignID, ParentTable)">
-                <table name="GIOn" uplink="(DesignID, LineNbr) = (DesignID, RelationNbr)">
-                    <table name="Note" uplink="(NoteID) = (NoteID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-            </table>
-            <table name="GIResult" uplink="(Alias, DesignID) = (ObjectName, DesignID)">
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="GIResultKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIWhere" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="SiteMap" uplink="(DesignID) = (Url)" linkname="toDesignById">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(Name) = (Url)" linkname="toDesignByName">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(PrimaryScreenIDNew) = (ScreenID)" linkname="to1Screen">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="Note" uplink="(NoteID) = (NoteID)" />
-    </table>
-</layout>
-    <data>
-      <GIDesign>
-        <row DesignID="1ce25f0a-cde6-4f0a-b939-d274fe343574" Name="DRP_VelocityHistory" ScreenID="SB401080" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
-          <GITable Alias="SOShipLine" Name="PX.Objects.SO.SOShipLine">
-            <GIRelation LineNbr="1" ChildTable="SOShipment" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="ShipmentNbr" Condition="E " ChildField="ShipmentNbr" Operation="A" />
-            </GIRelation>
-            <GIRelation LineNbr="2" ChildTable="SOLine" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="OrigOrderType" Condition="E " ChildField="OrderType" Operation="A" />
-              <GIOn LineNbr="2" ParentField="OrigOrderNbr" Condition="E " ChildField="OrderNbr" Operation="A" />
-              <GIOn LineNbr="3" ParentField="OrigLineNbr" Condition="E " ChildField="LineNbr" Operation="A" />
-            </GIRelation>
-            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="InventoryID" Width="120" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="ecce5bee-e6cc-4c36-9636-eb69f32d9047" />
-            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="ShippedQty" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Shipped Qty" RowID="b4130772-382a-428b-8bc1-dec67f717da2" />
-            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="OrigOrderType" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="SO Type" RowID="f0fbb9dd-6d4e-491e-b29c-58ecaea6b06d" />
-            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="OrigOrderNbr" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="SO Nbr" RowID="da571808-98c9-4843-8418-3e864278c52c" />
-            <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="SiteID" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Site" RowID="7f7b5991-23b6-4c61-8a6a-3cdec6aac5f6" />
-            <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="UOM" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="UOM" RowID="7a7b593d-a702-4a58-9ef2-f56ab8ed493b" />
-          </GITable>
-          <GITable Alias="SOShipment" Name="PX.Objects.SO.SOShipment">
-            <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="ShipDate" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Shipped Date" RowID="84dcef53-9d20-4bb9-a928-f8cccedfc6e6" />
-          </GITable>
-          <GITable Alias="SOLine" Name="PX.Objects.SO.SOLine">
-            <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="CustomerID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Customer" RowID="3dc9d2ad-cb01-4bac-b9ca-ea4af2e3b247" />
-          </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="SOShipment.Confirmed" Condition="E " IsExpression="0" Value1="True" Operation="A" />
-          <GIWhere LineNbr="2" IsActive="1" DataFieldName="SOShipment.Operation" Condition="E " IsExpression="0" Value1="I" Operation="A" />
-          <GISort LineNbr="1" IsActive="1" DataFieldName="SOShipment.ShipDate" SortOrder="D" />
-          <SiteMap linkname="toDesignById">
-            <row Position="1160" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=1ce25f0a-cde6-4f0a-b939-d274fe343574" Expanded="0" IsFolder="0" ScreenID="SB401080" NodeID="aed2bb14-04d3-4715-ba57-6bd405423270" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
-              <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2070" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
-              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-            </row>
-          </SiteMap>
-
-        </row>
-      </GIDesign>
-    </data>
-  </data-set>
-</GenericInquiryScreen>
-    <GenericInquiryScreen>
-  <data-set>
-                <relations format-version="3" relations-version="20240201" main-table="GIDesign" stable-sharing="True" file-name="(Name)">
-    <link from="GIFilter (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIGroupBy (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassAction (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassUpdateField (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationScreen (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationParameter (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GINavigationCondition (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GIOn (DesignID, RelationNbr)" to="GIRelation (DesignID, LineNbr)" />
-    <link from="GIRecordDefault (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIRelation (DesignID, ParentTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIRelation (DesignID, ChildTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIResult (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIResult (ObjectName, DesignID)" to="GITable (Alias, DesignID)" />
-    <link from="GISort (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GITable (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIWhere (DesignID)" to="GIDesign (DesignID)" />
-    <link from="SiteMap (Url)" to="GIDesign (DesignID)" type="WeakByUrl" linkname="toDesignById" baseurl="~/GenericInquiry/GenericInquiry.aspx" paramnames="id" />
-    <link from="SiteMap (Url)" to="GIDesign (Name)" type="WeakByUrl" linkname="toDesignByName" baseurl="~/GenericInquiry/GenericInquiry.aspx" />
-    <link from="ListEntryPoint (ListScreenID)" to="SiteMap (ScreenID)" />
-    <link from="SiteMap (ScreenID)" to="GIDesign (PrimaryScreenIDNew)" linkname="to1Screen" />
-    <link from="FilterHeader (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="FilterRow (FilterID)" to="FilterHeader (FilterID)" />
-    <link from="PivotTable (NoteID)" to="FilterHeader (RefNoteID)" />
-    <link from="PivotField (ScreenID, PivotTableID)" to="PivotTable (ScreenID, PivotTableID)" />
-    <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
-    <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
-    <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
-    <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
-    <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="GIDesign (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="GIFilterKvExt (RecordID)" type="RowKvExt" />
-    <link from="GIGroupBy (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIOn (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIRelation (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="GIResultKvExt (RecordID)" type="RowKvExt" />
-    <link from="GISort (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GITable (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIWhere (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="FilterHeaderKvExt (RecordID)" type="RowKvExt" />
-</relations>
-            <layout>
-    <table name="GIDesign">
-        <table name="GIFilter" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-            <table name="GIFilterKvExt" uplink="(NoteID) = (RecordID)" />
-        </table>
-        <table name="GIGroupBy" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIMassAction" uplink="(DesignID) = (DesignID)" />
-        <table name="GIMassUpdateField" uplink="(DesignID) = (DesignID)" />
-        <table name="GINavigationScreen" uplink="(DesignID) = (DesignID)">
-            <table name="GINavigationParameter" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-            <table name="GINavigationCondition" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-        </table>
-        <table name="GIRecordDefault" uplink="(DesignID) = (DesignID)" />
-        <table name="GISort" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GITable" uplink="(DesignID) = (DesignID)">
-            <table name="GIRelation" uplink="(DesignID, Alias) = (DesignID, ParentTable)">
-                <table name="GIOn" uplink="(DesignID, LineNbr) = (DesignID, RelationNbr)">
-                    <table name="Note" uplink="(NoteID) = (NoteID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-            </table>
-            <table name="GIResult" uplink="(Alias, DesignID) = (ObjectName, DesignID)">
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="GIResultKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIWhere" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="SiteMap" uplink="(DesignID) = (Url)" linkname="toDesignById">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(Name) = (Url)" linkname="toDesignByName">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(PrimaryScreenIDNew) = (ScreenID)" linkname="to1Screen">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="Note" uplink="(NoteID) = (NoteID)" />
-    </table>
-</layout>
-    <data>
-      <GIDesign>
-        <row DesignID="f918a504-7620-461c-aad8-f1b3395d1e79" Name="DRP_OpenSOCommitments" ScreenID="SB401090" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
-          <GITable Alias="SOOrder" Name="PX.Objects.SO.SOOrder">
-            <GIRelation LineNbr="1" ChildTable="SOLine" IsActive="1" JoinType="I">
-              <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
-              <GIOn LineNbr="2" ParentField="OrderNbr" Condition="E " ChildField="OrderNbr" Operation="A" />
-            </GIRelation>
-            <GIResult LineNbr="9" SortOrder="9" IsActive="1" Field="CustomerID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Customer" RowID="3ec70280-a871-419e-9525-6a117a502b6f" />
-          </GITable>
-          <GITable Alias="SOLine" Name="PX.Objects.SO.SOLine">
-            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="InventoryID" Width="120" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="2d95b7be-2bb2-406f-bddd-2bc9fe95f567" />
-            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="OrderType" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="SO Type" RowID="d120b57e-74b5-4ca2-8567-024fcbafa79e" />
-            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="OrderNbr" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="SO Nbr" RowID="640b01fe-d1a2-4b7d-99a4-5db8f2348195" />
-            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="LineNbr" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Line Nbr" RowID="56581d1c-89dc-4458-8e0e-49905f93fcf1" />
-            <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="OrderQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Order Qty" RowID="8e257121-86d8-46ff-944c-4a0f8dd8459e" />
-            <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="ShippedQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Shipped Qty" RowID="ea7b4ec5-17d0-40b4-ba57-32ad3f1cb0e7" />
-            <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="OpenQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Open Qty" RowID="b820f682-e2a8-401c-8d9e-5c5004b8d6ea" />
-            <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="RequestDate" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Req Ship Date" RowID="8f870880-3313-497e-9846-41f3286ecad0" />
-            <GIResult LineNbr="10" SortOrder="10" IsActive="1" Field="SiteID" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Site" RowID="7501a3a2-2147-4369-96f6-f44490f8440a" />
-            <GIResult LineNbr="11" SortOrder="11" IsActive="1" Field="UOM" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="UOM" RowID="812a72b9-c8bc-47b8-a738-e839a814a529" />
-          </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="SOLine.LineType" Condition="E " IsExpression="0" Value1="GI" Operation="A" />
-          <GIWhere LineNbr="2" IsActive="1" DataFieldName="SOLine.OpenQty" Condition="G " IsExpression="0" Value1="0" Operation="A" />
-          <GIWhere LineNbr="3" OpenBrackets="1" IsActive="1" DataFieldName="SOLine.OrderType" Condition="E " IsExpression="0" Value1="CO" Operation="O" />
-          <GIWhere LineNbr="4" IsActive="1" DataFieldName="SOLine.OrderType" Condition="E " IsExpression="0" Value1="SO" Operation="O" />
-          <GIWhere LineNbr="5" CloseBrackets="1" IsActive="1" DataFieldName="SOLine.OrderType" Condition="E " IsExpression="0" Value1="PC" Operation="A" />
-          <GISort LineNbr="1" IsActive="1" DataFieldName="SOLine.RequestDate" SortOrder="A" />
-          <SiteMap linkname="toDesignById">
-            <row Position="1170" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=f918a504-7620-461c-aad8-f1b3395d1e79" Expanded="0" IsFolder="0" ScreenID="SB401090" NodeID="af758f49-f888-4d32-b162-838a5fa34c52" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
-              <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2080" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
-              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-            </row>
-          </SiteMap>
-
-        </row>
-      </GIDesign>
-    </data>
-  </data-set>
-</GenericInquiryScreen>
-    <GenericInquiryScreen>
-  <data-set>
-                <relations format-version="3" relations-version="20240201" main-table="GIDesign" stable-sharing="True" file-name="(Name)">
-    <link from="GIFilter (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIGroupBy (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassAction (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassUpdateField (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationScreen (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationParameter (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GINavigationCondition (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GIOn (DesignID, RelationNbr)" to="GIRelation (DesignID, LineNbr)" />
-    <link from="GIRecordDefault (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIRelation (DesignID, ParentTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIRelation (DesignID, ChildTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIResult (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIResult (ObjectName, DesignID)" to="GITable (Alias, DesignID)" />
-    <link from="GISort (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GITable (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIWhere (DesignID)" to="GIDesign (DesignID)" />
-    <link from="SiteMap (Url)" to="GIDesign (DesignID)" type="WeakByUrl" linkname="toDesignById" baseurl="~/GenericInquiry/GenericInquiry.aspx" paramnames="id" />
-    <link from="SiteMap (Url)" to="GIDesign (Name)" type="WeakByUrl" linkname="toDesignByName" baseurl="~/GenericInquiry/GenericInquiry.aspx" />
-    <link from="ListEntryPoint (ListScreenID)" to="SiteMap (ScreenID)" />
-    <link from="SiteMap (ScreenID)" to="GIDesign (PrimaryScreenIDNew)" linkname="to1Screen" />
-    <link from="FilterHeader (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="FilterRow (FilterID)" to="FilterHeader (FilterID)" />
-    <link from="PivotTable (NoteID)" to="FilterHeader (RefNoteID)" />
-    <link from="PivotField (ScreenID, PivotTableID)" to="PivotTable (ScreenID, PivotTableID)" />
-    <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
-    <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
-    <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
-    <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
-    <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="GIDesign (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="GIFilterKvExt (RecordID)" type="RowKvExt" />
-    <link from="GIGroupBy (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIOn (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIRelation (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="GIResultKvExt (RecordID)" type="RowKvExt" />
-    <link from="GISort (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GITable (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIWhere (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="FilterHeaderKvExt (RecordID)" type="RowKvExt" />
-</relations>
-            <layout>
-    <table name="GIDesign">
-        <table name="GIFilter" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-            <table name="GIFilterKvExt" uplink="(NoteID) = (RecordID)" />
-        </table>
-        <table name="GIGroupBy" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIMassAction" uplink="(DesignID) = (DesignID)" />
-        <table name="GIMassUpdateField" uplink="(DesignID) = (DesignID)" />
-        <table name="GINavigationScreen" uplink="(DesignID) = (DesignID)">
-            <table name="GINavigationParameter" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-            <table name="GINavigationCondition" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-        </table>
-        <table name="GIRecordDefault" uplink="(DesignID) = (DesignID)" />
-        <table name="GISort" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GITable" uplink="(DesignID) = (DesignID)">
-            <table name="GIRelation" uplink="(DesignID, Alias) = (DesignID, ParentTable)">
-                <table name="GIOn" uplink="(DesignID, LineNbr) = (DesignID, RelationNbr)">
-                    <table name="Note" uplink="(NoteID) = (NoteID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-            </table>
-            <table name="GIResult" uplink="(Alias, DesignID) = (ObjectName, DesignID)">
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="GIResultKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIWhere" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="SiteMap" uplink="(DesignID) = (Url)" linkname="toDesignById">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(Name) = (Url)" linkname="toDesignByName">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(PrimaryScreenIDNew) = (ScreenID)" linkname="to1Screen">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="Note" uplink="(NoteID) = (NoteID)" />
-    </table>
-</layout>
-    <data>
-      <GIDesign>
-        <row DesignID="a5337a02-6d79-42e9-b400-d7178ac3fd24" Name="DRP_InventoryBySite" ScreenID="SB401110" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
-          <GITable Alias="InventoryItem" Name="PX.Objects.IN.InventoryItem">
-            <GIRelation LineNbr="1" ChildTable="INSiteStatus" IsActive="1" JoinType="I">
-              <GIOn LineNbr="1" ParentField="InventoryID" Condition="E " ChildField="InventoryID" Operation="A" />
-            </GIRelation>
-            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="InventoryCD" Width="120" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="79173e70-3a85-4d70-a5a4-cd71ae7ae80e" />
-            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="Descr" Width="220" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Description" RowID="872a8b14-9db6-4978-8214-32c8f5670646" />
-            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="ItemStatus" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Status" RowID="e24ba55f-863f-45be-a4f9-7ed06db4b49b" />
-            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="ItemClassID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Item Class" RowID="6b15d7cd-e2f1-4166-a7b4-b2b7c6fd1eed" />
-          </GITable>
-          <GITable Alias="INSiteStatus" Name="PX.Objects.IN.INSiteStatus">
-            <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="SiteID" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Site" RowID="45834d20-dc12-430f-a291-9c8b3576f12a" />
-            <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="QtyOnHand" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty On Hand" RowID="169233bb-3c3e-4657-8dcd-cba20887a558" />
-            <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="QtyAvail" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty Available" RowID="8ce9d3cb-34ed-4983-85e3-00b844b380eb" />
-            <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="QtyHardAvail" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty Hard Avail" RowID="d1cb550a-2817-4469-ab21-742e368f2ee5" />
-            <GIResult LineNbr="9" SortOrder="9" IsActive="1" Field="QtyAllocated" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Qty Allocated" RowID="78f5dc04-3821-493e-822d-984b1805f2d5" />
-          </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="InventoryItem.StkItem" Condition="E " IsExpression="0" Value1="True" Operation="A" />
-          <GIWhere LineNbr="2" OpenBrackets="1" IsActive="1" DataFieldName="InventoryItem.ItemStatus" Condition="E " IsExpression="0" Value1="AC" Operation="O" />
-          <GIWhere LineNbr="3" CloseBrackets="1" IsActive="1" DataFieldName="InventoryItem.ItemStatus" Condition="E " IsExpression="0" Value1="NS" Operation="A" />
-          <GISort LineNbr="1" IsActive="1" DataFieldName="InventoryItem.InventoryCD" SortOrder="A" />
-          <GISort LineNbr="2" IsActive="1" DataFieldName="INSiteStatus.SiteID" SortOrder="A" />
-          <SiteMap linkname="toDesignById">
-            <row Position="1180" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=a5337a02-6d79-42e9-b400-d7178ac3fd24" Expanded="0" IsFolder="0" ScreenID="SB401110" NodeID="1fb65d0f-ebc6-4ec5-8e19-5c5022245ff5" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
-              <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2090" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
-              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-            </row>
-          </SiteMap>
-
-        </row>
-      </GIDesign>
-    </data>
-  </data-set>
-</GenericInquiryScreen>
-    <GenericInquiryScreen>
-  <data-set>
-                <relations format-version="3" relations-version="20240201" main-table="GIDesign" stable-sharing="True" file-name="(Name)">
-    <link from="GIFilter (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIGroupBy (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassAction (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIMassUpdateField (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationScreen (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GINavigationParameter (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GINavigationCondition (DesignID, NavigationScreenLineNbr)" to="GINavigationScreen (DesignID, LineNbr)" />
-    <link from="GIOn (DesignID, RelationNbr)" to="GIRelation (DesignID, LineNbr)" />
-    <link from="GIRecordDefault (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIRelation (DesignID, ParentTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIRelation (DesignID, ChildTable)" to="GITable (DesignID, Alias)" />
-    <link from="GIResult (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIResult (ObjectName, DesignID)" to="GITable (Alias, DesignID)" />
-    <link from="GISort (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GITable (DesignID)" to="GIDesign (DesignID)" />
-    <link from="GIWhere (DesignID)" to="GIDesign (DesignID)" />
-    <link from="SiteMap (Url)" to="GIDesign (DesignID)" type="WeakByUrl" linkname="toDesignById" baseurl="~/GenericInquiry/GenericInquiry.aspx" paramnames="id" />
-    <link from="SiteMap (Url)" to="GIDesign (Name)" type="WeakByUrl" linkname="toDesignByName" baseurl="~/GenericInquiry/GenericInquiry.aspx" />
-    <link from="ListEntryPoint (ListScreenID)" to="SiteMap (ScreenID)" />
-    <link from="SiteMap (ScreenID)" to="GIDesign (PrimaryScreenIDNew)" linkname="to1Screen" />
-    <link from="FilterHeader (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="FilterRow (FilterID)" to="FilterHeader (FilterID)" />
-    <link from="PivotTable (NoteID)" to="FilterHeader (RefNoteID)" />
-    <link from="PivotField (ScreenID, PivotTableID)" to="PivotTable (ScreenID, PivotTableID)" />
-    <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
-    <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
-    <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
-    <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
-    <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
-    <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
-    <link from="GIDesign (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIFilter (NoteID)" to="GIFilterKvExt (RecordID)" type="RowKvExt" />
-    <link from="GIGroupBy (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIOn (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIRelation (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIResult (NoteID)" to="GIResultKvExt (RecordID)" type="RowKvExt" />
-    <link from="GISort (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GITable (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="GIWhere (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="Note (NoteID)" type="Note" />
-    <link from="FilterHeader (NoteID)" to="FilterHeaderKvExt (RecordID)" type="RowKvExt" />
-</relations>
-            <layout>
-    <table name="GIDesign">
-        <table name="GIFilter" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-            <table name="GIFilterKvExt" uplink="(NoteID) = (RecordID)" />
-        </table>
-        <table name="GIGroupBy" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIMassAction" uplink="(DesignID) = (DesignID)" />
-        <table name="GIMassUpdateField" uplink="(DesignID) = (DesignID)" />
-        <table name="GINavigationScreen" uplink="(DesignID) = (DesignID)">
-            <table name="GINavigationParameter" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-            <table name="GINavigationCondition" uplink="(DesignID, LineNbr) = (DesignID, NavigationScreenLineNbr)" />
-        </table>
-        <table name="GIRecordDefault" uplink="(DesignID) = (DesignID)" />
-        <table name="GISort" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GITable" uplink="(DesignID) = (DesignID)">
-            <table name="GIRelation" uplink="(DesignID, Alias) = (DesignID, ParentTable)">
-                <table name="GIOn" uplink="(DesignID, LineNbr) = (DesignID, RelationNbr)">
-                    <table name="Note" uplink="(NoteID) = (NoteID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-            </table>
-            <table name="GIResult" uplink="(Alias, DesignID) = (ObjectName, DesignID)">
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="GIResultKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="GIWhere" uplink="(DesignID) = (DesignID)">
-            <table name="Note" uplink="(NoteID) = (NoteID)" />
-        </table>
-        <table name="SiteMap" uplink="(DesignID) = (Url)" linkname="toDesignById">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(Name) = (Url)" linkname="toDesignByName">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="SiteMap" uplink="(PrimaryScreenIDNew) = (ScreenID)" linkname="to1Screen">
-            <table name="ListEntryPoint" uplink="(ScreenID) = (ListScreenID)" />
-            <table name="FilterHeader" uplink="(ScreenID) = (ScreenID)">
-                <table name="FilterRow" uplink="(FilterID) = (FilterID)" />
-                <table name="PivotTable" uplink="(RefNoteID) = (NoteID)">
-                    <table name="PivotField" uplink="(ScreenID, PivotTableID) = (ScreenID, PivotTableID)" />
-                </table>
-                <table name="Note" uplink="(NoteID) = (NoteID)" />
-                <table name="FilterHeaderKvExt" uplink="(NoteID) = (RecordID)" />
-            </table>
-            <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
-                <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
-            </table>
-            <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
-        </table>
-        <table name="Note" uplink="(NoteID) = (NoteID)" />
-    </table>
-</layout>
-    <data>
-      <GIDesign>
-        <row DesignID="89912975-c6ed-41ad-b514-a0f775a89362" Name="DRP_OpenPOLines" ScreenID="SB401100" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
-          <GITable Alias="POOrder" Name="PX.Objects.PO.POOrder">
-            <GIRelation LineNbr="1" ChildTable="Line" IsActive="1" JoinType="I">
-              <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
-              <GIOn LineNbr="2" ParentField="OrderNbr" Condition="E " ChildField="OrderNbr" Operation="A" />
-            </GIRelation>
-            <GIResult LineNbr="10" SortOrder="10" IsActive="1" Field="UsrAcknowledgedDate" Width="110" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Vendor Ack'd" RowID="ccc39a8e-89cf-435f-8e39-c35ecd032bc6" />
-            <GIResult LineNbr="11" SortOrder="11" IsActive="1" Field="UsrFactoryReadyDate" Width="110" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Factory Ready" RowID="db94eb69-50b0-468b-ac76-81f3515ce171" />
-          </GITable>
-          <GITable Alias="Line" Name="PX.Objects.PO.POLine">
-            <GIRelation LineNbr="2" ChildTable="ContainerLink" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
-              <GIOn LineNbr="2" ParentField="OrderNbr" Condition="E " ChildField="OrderNbr" Operation="A" />
-              <GIOn LineNbr="3" ParentField="LineNbr" Condition="E " ChildField="LineNbr" Operation="A" />
-            </GIRelation>
-            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="OrderType" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="PO Type" RowID="d708e601-603b-4976-a9d6-87995b39b562" />
-            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="OrderNbr" Width="100" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="PO Nbr" RowID="a4ca68b7-fd7c-4fc5-b2b9-37561a4b356e" />
-            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="LineNbr" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Line Nbr" RowID="3a6373a9-0922-4901-8364-dc3408bf9221" />
-            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="InventoryID" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="54ff852c-644c-484f-8cbe-0a01889b92ad" />
-            <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="VendorID" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Vendor" RowID="f8643af1-993a-480b-90bb-d0110be7e72e" />
-            <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="OrderQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Order Qty" RowID="a249525f-f5a8-42cb-afb9-8ce335e331f0" />
-            <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="ReceivedQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Received" RowID="d1e7376f-f209-4d68-924e-5e6bff3d4d79" />
-            <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="OpenQty" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Open Qty" RowID="a7b6ebc5-24a5-4827-89fd-f3d1f1b70eec" />
-            <GIResult LineNbr="9" SortOrder="9" IsActive="1" Field="PromisedDate" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Promised Date" RowID="202a8b2e-87d7-4407-ae00-80a992b5686b" />
-          </GITable>
-          <GITable Alias="ContainerLink" Name="StudioB.Containers.UsrContainerPOLink">
-            <GIRelation LineNbr="3" ChildTable="Container" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="ContainerID" Condition="E " ChildField="ContainerID" Operation="A" />
-            </GIRelation>
-          </GITable>
-          <GITable Alias="Container" Name="StudioB.Containers.UsrContainer">
-            <GIResult LineNbr="12" SortOrder="12" IsActive="1" Field="ContainerCD" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Container Nbr" RowID="93ed61d7-5194-4c5e-9c2e-dc02f6a7059b" />
-          </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="Line.LineType" Condition="E " IsExpression="0" Value1="GI" Operation="A" />
-          <GIWhere LineNbr="2" IsActive="1" DataFieldName="Line.OpenQty" Condition="G " IsExpression="0" Value1="0" Operation="A" />
-          <GIWhere LineNbr="3" OpenBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="N" Operation="O" />
-          <GIWhere LineNbr="4" CloseBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="O" Operation="A" />
-          <GISort LineNbr="1" IsActive="1" DataFieldName="Line.PromisedDate" SortOrder="A" />
-          <SiteMap linkname="toDesignById">
-            <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="660b0c64-b2bf-4848-a863-468f5ff34fbd" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
-              <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
-              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-            </row>
-          </SiteMap>
-
-        </row>
-        <row DesignID="6e77b05f-ef4d-49e7-90ac-4c703006880d" Name="DRP_ItemWarehouseSettings" ScreenID="SB401120" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
-          <GITable Alias="INItemSite" Name="PX.Objects.IN.INItemSite">
-            <GIRelation LineNbr="1" ChildTable="InventoryItem" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="InventoryID" Condition="E " ChildField="InventoryID" Operation="A" />
-            </GIRelation>
-            <GIRelation LineNbr="2" ChildTable="INSite" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="SiteID" Condition="E " ChildField="SiteID" Operation="A" />
-            </GIRelation>
-            <GIRelation LineNbr="3" ChildTable="POVendorInventory" IsActive="1" JoinType="L">
-              <GIOn LineNbr="1" ParentField="InventoryID" Condition="E " ChildField="InventoryID" Operation="A" />
-              <GIOn LineNbr="2" ParentField="PreferredVendorID" Condition="E " ChildField="VendorID" Operation="A" />
-            </GIRelation>
-            <GIResult LineNbr="4" SortOrder="4" IsActive="1" Field="SafetyStock" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Safety Stock" RowID="30357e10-590f-48d6-9bc9-4533b4353300" />
-            <GIResult LineNbr="5" SortOrder="5" IsActive="1" Field="MinQty" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Reorder Point" RowID="1fd0bf01-6062-412f-848c-7cc803aaf88a" />
-            <GIResult LineNbr="6" SortOrder="6" IsActive="1" Field="MaxQty" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Max Qty" RowID="a7483a20-c13d-458f-b167-39c4d6733fd3" />
-            <GIResult LineNbr="7" SortOrder="7" IsActive="1" Field="MinOrdQty" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Min Order Qty" RowID="0d734a9c-4fb0-4a15-aba3-ef6d1bcc2fbf" />
-            <GIResult LineNbr="8" SortOrder="8" IsActive="1" Field="ReplenishmentSource" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Replenishment Source" RowID="e01b5ea1-7dd7-4be8-a983-e3a17b7a2f41" />
-            <GIResult LineNbr="9" SortOrder="9" IsActive="1" Field="ReplenishmentPolicyOverride" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Override Settings" RowID="aee7e44e-7ade-43a0-8485-4b6e0a1fb4bd" />
-            <GIResult LineNbr="10" SortOrder="10" IsActive="1" Field="PreferredVendorID" Width="120" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Preferred Vendor" RowID="7405ecbc-7ff1-4474-aa32-2a777ae48c23" />
-            <GIResult LineNbr="12" SortOrder="12" IsActive="1" Field="ABCCodeID" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="ABC Code" RowID="def1c599-a2ff-4b18-ab0c-6358c8c5430a" />
-          </GITable>
-          <GITable Alias="POVendorInventory" Name="PX.Objects.PO.POVendorInventory">
-            <GIResult LineNbr="11" SortOrder="11" IsActive="1" Field="VLeadTime" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Lead Time (Days)" RowID="68b19a50-2a69-408c-948f-c5cbc2db0a02" />
-            <GIResult LineNbr="13" SortOrder="13" IsActive="1" Field="AddLeadTimeDays" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Add Lead Time (Days)" RowID="5d81b185-d1ad-40e8-8ca0-c1f42dd03746" />
-          </GITable>
-          <GITable Alias="InventoryItem" Name="PX.Objects.IN.InventoryItem">
-            <GIResult LineNbr="1" SortOrder="1" IsActive="1" Field="InventoryCD" Width="120" IsVisible="1" DefaultNav="1" QuickFilter="0" FastFilter="1" Caption="Inventory ID" RowID="5cbd9931-6bc5-4c98-868b-61aeb474664e" />
-            <GIResult LineNbr="3" SortOrder="3" IsActive="1" Field="BaseUnit" Width="60" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Base Unit" RowID="06d931cc-52c8-45f6-9c42-0cab8b665a26" />
-          </GITable>
-          <GITable Alias="INSite" Name="PX.Objects.IN.INSite">
-            <GIResult LineNbr="2" SortOrder="2" IsActive="1" Field="SiteCD" Width="80" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Warehouse" RowID="6e902077-a0b8-44e6-b569-ea12bc1242e4" />
-          </GITable>
-          <GIWhere LineNbr="1" IsActive="1" DataFieldName="InventoryItem.StkItem" Condition="E " IsExpression="0" Value1="True" Operation="A" />
-          <GIWhere LineNbr="2" OpenBrackets="1" IsActive="1" DataFieldName="InventoryItem.ItemStatus" Condition="E " IsExpression="0" Value1="AC" Operation="O" />
-          <GIWhere LineNbr="3" CloseBrackets="1" IsActive="1" DataFieldName="InventoryItem.ItemStatus" Condition="E " IsExpression="0" Value1="NS" Operation="A" />
-          <GISort LineNbr="1" IsActive="1" DataFieldName="InventoryItem.InventoryCD" SortOrder="A" />
-          <GISort LineNbr="2" IsActive="1" DataFieldName="INSite.SiteCD" SortOrder="A" />
-          <SiteMap linkname="toDesignById">
-            <row Position="1190" Title="DRP Item Warehouse Settings" Url="~/GenericInquiry/GenericInquiry.aspx?id=6e77b05f-ef4d-49e7-90ac-4c703006880d" Expanded="0" IsFolder="0" ScreenID="SB401120" NodeID="3e124ece-6462-4be9-acc7-6372d6da32ef" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
-              <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
-              <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-              <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-            </row>
-          </SiteMap>
-
-        </row>
-      </GIDesign>
-    </data>
-  </data-set>
-</GenericInquiryScreen>
     <ScreenWithRights AccessRightsMergeRule="ApplyAndKeep">
         <data-set>
             <relations format-version="3" relations-version="20240201" main-table="SiteMap">
@@ -2838,22 +2488,6 @@ public partial class Page_SB_SB302040 : PXPage
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>
                     <row Position="0" Title="Landed Cost Summary" Url="~/GenericInquiry/GenericInquiry.aspx?id=6a7d8fbb-a1ae-4559-adf8-e5e63cb4c05d" ScreenID="SB401070" NodeID="6a7d8fbb-a1ae-4559-adf8-e5e63cb4c05d" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
-                        <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-                        <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-                    </row>
-                    <row Position="0" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=1ce25f0a-cde6-4f0a-b939-d274fe343574" ScreenID="SB401080" NodeID="1ce25f0a-cde6-4f0a-b939-d274fe343574" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
-                        <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-                        <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-                    </row>
-                    <row Position="0" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=f918a504-7620-461c-aad8-f1b3395d1e79" ScreenID="SB401090" NodeID="f918a504-7620-461c-aad8-f1b3395d1e79" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
-                        <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-                        <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-                    </row>
-                    <row Position="0" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362" ScreenID="SB401100" NodeID="89912975-c6ed-41ad-b514-a0f775a89362" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
-                        <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
-                        <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
-                    </row>
-                    <row Position="0" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=a5337a02-6d79-42e9-b400-d7178ac3fd24" ScreenID="SB401110" NodeID="a5337a02-6d79-42e9-b400-d7178ac3fd24" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>

--- a/scripts/heritage/validate_publish_gi.py
+++ b/scripts/heritage/validate_publish_gi.py
@@ -11,11 +11,12 @@ PXGenericInqGrph+Definition on app pool restart).
 PROBE_GIS = [
     "InventoryAllocationDetail",
     "LotAvailability",
-    # DRP Phase 0 Stream A (2026-04-09) — inline GIs in AesthetikContainers
-    "DRP_VelocityHistory",     # SB401080 — SOShipLine × SOShipment × SOLine
-    "DRP_OpenSOCommitments",   # SB401090 — SOLine × SOOrder
-    "DRP_OpenPOLines",         # SB401100 — POLine × POOrder × UsrContainerPOLink × UsrContainer
-    "DRP_InventoryBySite",     # SB401110 — InventoryItem × INSiteStatus
+    # DRP Phase 0 Stream A — SQL-installed GIs in AesthetikContainers (no ScreenID)
+    "DRP_VelocityHistory",        # SOShipLine × SOShipment × SOLine
+    "DRP_OpenSOCommitments",      # SOOrder × SOLine
+    "DRP_OpenPOLines",            # POOrder × POLine × UsrContainerPOLink × UsrContainer
+    "DRP_InventoryBySite",        # InventoryItem × INSiteStatus
+    "DRP_ItemWarehouseSettings",  # INItemSite × InventoryItem × INSite × POVendorInventory
 ]
 
 RED = "\033[91m"

--- a/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
+++ b/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
@@ -385,8 +385,9 @@ namespace StudioB.Containers
                         try { EnsureContainerTrackingSiteMap(conn, companyId); }
                         catch (Exception ex) { WriteLog(string.Format("[AesthetikContainers] SiteMap update failed CID={0}: {1}", companyId, ex.Message)); }
 
-                        try { EnsureDRPGISiteMap(conn, companyId); }
-                        catch (Exception ex) { WriteLog(string.Format("[AesthetikContainers] DRP GI SiteMap failed CID={0}: {1}", companyId, ex.Message)); }
+                        // EnsureDRPGISiteMap removed — DRP GIs are now SQL-installed
+                        // with no ScreenID/SiteMap. EnsureContainerTrackingSiteMap
+                        // cleans up any stale SiteMap entries from prior publishes.
 
                         try { EnsureItemUomConsistency(conn, companyId); }
                         catch (Exception ex) { WriteLog(string.Format("[AesthetikContainers] EnsureItemUomConsistency failed CID={0}: {1}", companyId, ex.Message)); }
@@ -625,72 +626,10 @@ namespace StudioB.Containers
             WriteLog(string.Format("[AesthetikContainers] Container Tracking SiteMap (5 form screens) for CompanyID={0} — OK", companyId));
         }
 
-        // ── EnsureDRPGISiteMap ─────────────────────────────────────────────
-        // 2026-04-13: DRP Generic Inquiries lose OData registration after CI/CD
-        // reimport. Root cause: SiteMap rows don't exist for GI screen IDs,
-        // so the OData endpoint returns 404 or 403. Fix: upsert SiteMap rows
-        // for all DRP GI screen IDs on every publish.
-        //
-        // Parent workspace: same Container Tracking workspace (DRP is under
-        // Inventory > Inquiries but SiteMap parent controls access tree).
-        private void EnsureDRPGISiteMap(SqlConnection conn, int companyId)
-        {
-            // DRP GI screen IDs — must match ScreenID in project.xml <GIDesign> rows
-            string[][] entries = new[]
-            {
-                new[] { "SB401080", "DRP Velocity History",    "~/GenericInquiry/GenericInquiry.aspx?id=1ce25f0a-cde6-4f0a-b939-d274fe343574", "20.1" },
-                new[] { "SB401090", "DRP Open SO Commitments", "~/GenericInquiry/GenericInquiry.aspx?id=f918a504-7620-461c-aad8-f1b3395d1e79", "20.2" },
-                new[] { "SB401100", "DRP Open PO Lines",       "~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362", "20.3" },
-                new[] { "SB401110", "DRP Inventory By Site",   "~/GenericInquiry/GenericInquiry.aspx?id=a5337a02-6d79-42e9-b400-d7178ac3fd24", "20.4" },
-            };
-
-            foreach (var e in entries)
-            {
-                string sql = @"
-                    IF EXISTS (SELECT 1 FROM SiteMap WHERE ScreenID = @sid AND CompanyID = @cid)
-                        UPDATE SiteMap SET Url = @url, Title = @title, Position = @pos
-                        WHERE ScreenID = @sid AND CompanyID = @cid;
-                    ELSE
-                        INSERT INTO SiteMap (CompanyID, NodeID, ScreenID, Title, Url, Position, ParentID, SelectedUI, CreatedByID, CreatedByScreenID, CreatedDateTime, LastModifiedByID, LastModifiedByScreenID, LastModifiedDateTime)
-                        VALUES (@cid, NEWID(), @sid, @title, @url, @pos, '9c89e3db-7c47-43c0-8554-5d2c9f2c0e87', N'E', N'B5344897-037E-4D58-B5C3-1BDFD0F47BF4', N'SM208000', GETUTCDATE(), N'B5344897-037E-4D58-B5C3-1BDFD0F47BF4', N'SM208000', GETUTCDATE());";
-                using (var cmd = new SqlCommand(sql, conn))
-                {
-                    cmd.Parameters.AddWithValue("@cid", companyId);
-                    cmd.Parameters.AddWithValue("@sid", e[0]);
-                    cmd.Parameters.AddWithValue("@title", e[1]);
-                    cmd.Parameters.AddWithValue("@url", e[2]);
-                    cmd.Parameters.AddWithValue("@pos", e[3]);
-                    cmd.ExecuteNonQuery();
-                }
-            }
-
-            // Also fix any GI that got auto-assigned a GI6xxxxx Screen ID
-            // instead of the SB4010xx ID from project.xml. This happens when
-            // the GI was first created via UI before being imported via CI/CD.
-            string fixScreenId = @"
-                UPDATE GIDesign SET ScreenID = @newSid
-                WHERE Name = @giName AND CompanyID = @cid AND ScreenID <> @newSid";
-            string[][] giFixups = new[]
-            {
-                new[] { "DRP_VelocityHistory",    "SB401080" },
-                new[] { "DRP_OpenSOCommitments",   "SB401090" },
-                new[] { "DRP_OpenPOLines",         "SB401100" },
-                new[] { "DRP_InventoryBySite",     "SB401110" },
-            };
-            foreach (var fix in giFixups)
-            {
-                using (var cmd = new SqlCommand(fixScreenId, conn))
-                {
-                    cmd.Parameters.AddWithValue("@cid", companyId);
-                    cmd.Parameters.AddWithValue("@giName", fix[0]);
-                    cmd.Parameters.AddWithValue("@newSid", fix[1]);
-                    int rows = cmd.ExecuteNonQuery();
-                    if (rows > 0) WriteLog(string.Format("[AesthetikContainers] Fixed ScreenID for {0} → {1} (CID={2})", fix[0], fix[1], companyId));
-                }
-            }
-
-            WriteLog(string.Format("[AesthetikContainers] DRP GI SiteMap (4 inquiries) for CompanyID={0} — OK", companyId));
-        }
+        // EnsureDRPGISiteMap removed — DRP GIs are now SQL-installed via
+        // project.xml <Sql> blocks with no ScreenID/SiteMap. The old method
+        // upserted SiteMap entries and fixed ScreenIDs, which conflicted with
+        // the no-ScreenID approach that makes OData work without 403.
 
         // ── EnsureItemUomConsistency ────────────────────────────────────────
         // 2026-04-09 rewrite (supersedes PR #292/#299/#301/#302, closes PR #304).

--- a/tests/test_drp_phase0_gis.py
+++ b/tests/test_drp_phase0_gis.py
@@ -1,19 +1,24 @@
-"""Static XML-level assertions for the DRP Phase 0 Stream A GIs.
+"""Static SQL-level assertions for the DRP Phase 0 Stream A GIs.
 
-These GIs live as inline <GenericInquiryScreen> blocks inside
+These GIs are installed via SQL <Sql> blocks inside
 Customization/AesthetikContainers/project.xml. This test locks in:
-  - A.1 DRP_VelocityHistory   (ScreenID SB401080)
-  - A.2 DRP_OpenSOCommitments (ScreenID SB401090)
-  - A.4 DRP_InventoryBySite   (ScreenID SB401110)
+  - DRP_VelocityHistory
+  - DRP_OpenSOCommitments
+  - DRP_InventoryBySite
+  - DRP_OpenPOLines
+  - DRP_ItemWarehouseSettings
 
-Each GI must exist with the correct name / ScreenID, expected base tables,
-and expected result columns. This is deliberately an XML contract test —
-it runs fast, has no live Acumatica dependency, and catches silent drift
-from later edits to project.xml. Post-deploy live verification happens via
-scripts/heritage/validate_publish_gi.py and Playwright.
+Each GI must have a SQL installer script with the correct name,
+ExposeViaOData=1, expected table aliases, expected result fields,
+and NO ScreenID (which would trigger SiteMap access checks on OData).
+
+This is deliberately an offline contract test — it runs fast, has no
+live Acumatica dependency, and catches silent drift from later edits
+to project.xml.
 """
 from __future__ import annotations
 
+import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -27,130 +32,151 @@ PROJECT_XML = (
 )
 
 
-# Expected GI metadata: ScreenID → (Name, base_table_alias, required_result_fields)
+# Expected GI metadata: Name → (table_aliases, required_result_fields)
 EXPECTED_GIS = {
-    "SB401080": (
-        "DRP_VelocityHistory",
-        "SOShipLine",
+    "DRP_VelocityHistory": (
+        {"SOShipLine", "SOShipment", "SOLine"},
         {"InventoryID", "ShippedQty", "ShipDate", "OrigOrderType", "OrigOrderNbr",
          "CustomerID", "SiteID", "UOM"},
     ),
-    "SB401090": (
-        "DRP_OpenSOCommitments",
-        "SOLine",
+    "DRP_OpenSOCommitments": (
+        {"SOOrder", "SOLine"},
         {"InventoryID", "OrderType", "OrderNbr", "LineNbr", "OrderQty", "ShippedQty",
          "OpenQty", "RequestDate", "CustomerID", "SiteID", "UOM"},
     ),
-    "SB401100": (
-        "DRP_OpenPOLines",
-        "Line",
+    "DRP_OpenPOLines": (
+        {"POOrder", "Line", "ContainerLink", "Container"},
         {"OrderType", "OrderNbr", "LineNbr", "InventoryID", "VendorID", "OrderQty",
          "ReceivedQty", "OpenQty", "PromisedDate",
          "UsrAcknowledgedDate", "UsrFactoryReadyDate", "ContainerCD"},
     ),
-    "SB401110": (
-        "DRP_InventoryBySite",
-        "InventoryItem",
+    "DRP_InventoryBySite": (
+        {"InventoryItem", "INSiteStatus"},
         {"InventoryCD", "Descr", "ItemStatus", "ItemClassID", "SiteID", "QtyOnHand",
          "QtyAvail", "QtyHardAvail", "QtyAllocated"},
+    ),
+    "DRP_ItemWarehouseSettings": (
+        {"INItemSite", "InventoryItem", "INSite", "POVendorInventory"},
+        {"InventoryCD", "SiteCD", "BaseUnit", "SafetyStock", "MinQty", "MaxQty",
+         "MinOrdQty", "ReplenishmentSource", "ReplenishmentPolicyOverride",
+         "PreferredVendorID", "VLeadTime", "ABCCodeID", "AddLeadTimeDays"},
     ),
 }
 
 
 @pytest.fixture(scope="module")
-def root():
-    """Parse project.xml once per test module."""
+def sql_scripts():
+    """Parse project.xml and return dict of GI name → SQL script text."""
     assert PROJECT_XML.is_file(), f"{PROJECT_XML} not found"
-    return ET.parse(PROJECT_XML).getroot()
+    # Strip ASP.NET comments that break standard XML parsing
+    content = PROJECT_XML.read_text(encoding="utf-8")
+    cleaned = re.sub(r"<%--.*?--%>", "", content, flags=re.DOTALL)
+    root = ET.fromstring(cleaned)
 
-
-@pytest.fixture(scope="module")
-def drp_gi_rows(root):
-    """Return dict ScreenID → <GIDesign><row> element for the 3 DRP GIs.
-
-    Filters on DesignID presence because <SiteMap><row> elements share the
-    ScreenID attribute name but have NodeID instead of DesignID — and they'd
-    shadow the real GI rows in a naive filter.
-    """
-    out: dict[str, ET.Element] = {}
-    for row in root.findall(".//GIDesign/row"):
-        sid = row.get("ScreenID")
-        if sid in EXPECTED_GIS:
-            out[sid] = row
+    out: dict[str, str] = {}
+    for sql_el in root.findall("Sql"):
+        name = sql_el.get("Name", "")
+        if name.startswith("InstallDRP_") and name.endswith("GI"):
+            # Extract GI name from script name: InstallDRP_FooGI → DRP_Foo
+            gi_name = name[len("Install"):-len("GI")]
+            cdata = sql_el.find("CDATA")
+            if cdata is not None and cdata.text:
+                out[gi_name] = cdata.text
     return out
 
 
-@pytest.mark.parametrize("screen_id", sorted(EXPECTED_GIS.keys()))
-def test_drp_gi_exists(drp_gi_rows, screen_id):
-    """Every DRP Phase 0 GI has a <GIDesign><row> with the expected name."""
-    expected_name, _, _ = EXPECTED_GIS[screen_id]
-    assert screen_id in drp_gi_rows, (
-        f"Missing GI row for ScreenID {screen_id} ({expected_name}) "
-        f"in {PROJECT_XML}"
-    )
-    row = drp_gi_rows[screen_id]
-    assert row.get("Name") == expected_name, (
-        f"ScreenID {screen_id} has Name={row.get('Name')!r}, expected {expected_name!r}"
-    )
-    design_id = row.get("DesignID")
-    assert design_id, f"{screen_id} missing DesignID"
-    # DesignID must be a well-formed UUID (36 chars with hyphens)
-    assert len(design_id) == 36 and design_id.count("-") == 4, (
-        f"{screen_id} DesignID {design_id!r} not UUID-shaped"
+@pytest.mark.parametrize("gi_name", sorted(EXPECTED_GIS.keys()))
+def test_drp_gi_sql_script_exists(sql_scripts, gi_name):
+    """Every DRP GI has a SQL installer script in project.xml."""
+    assert gi_name in sql_scripts, (
+        f"Missing SQL installer script for {gi_name} in {PROJECT_XML}. "
+        f"Expected <Sql Name=\"Install{gi_name}GI\">."
     )
 
 
-@pytest.mark.parametrize("screen_id", sorted(EXPECTED_GIS.keys()))
-def test_drp_gi_exposes_via_odata(drp_gi_rows, screen_id):
-    """Every DRP GI must be ExposeViaOData=1 (Wave 4 code consumes them)."""
-    row = drp_gi_rows[screen_id]
-    assert row.get("ExposeViaOData") == "1", (
-        f"{screen_id} must have ExposeViaOData=1 so the DRP agent can read it"
+@pytest.mark.parametrize("gi_name", sorted(EXPECTED_GIS.keys()))
+def test_drp_gi_sql_has_review_marker(sql_scripts, gi_name):
+    """Every DRP GI SQL script has the gi-sql-safe review marker."""
+    sql = sql_scripts.get(gi_name, "")
+    assert "-- REVIEWED: gi-sql-safe" in sql, (
+        f"{gi_name} SQL script missing '-- REVIEWED: gi-sql-safe' marker"
     )
 
 
-@pytest.mark.parametrize("screen_id", sorted(EXPECTED_GIS.keys()))
-def test_drp_gi_has_base_table(drp_gi_rows, screen_id):
-    """Every DRP GI defines its expected base-table alias."""
-    _, expected_alias, _ = EXPECTED_GIS[screen_id]
-    row = drp_gi_rows[screen_id]
-    aliases = {t.get("Alias") for t in row.findall("GITable")}
-    assert expected_alias in aliases, (
-        f"{screen_id} expected base alias {expected_alias!r}, got {aliases}"
+@pytest.mark.parametrize("gi_name", sorted(EXPECTED_GIS.keys()))
+def test_drp_gi_sql_exposes_via_odata(sql_scripts, gi_name):
+    """Every DRP GI must set ExposeViaOData=1 in the GIDesign INSERT."""
+    sql = sql_scripts.get(gi_name, "")
+    assert "ExposeViaOData" in sql, (
+        f"{gi_name} SQL script missing ExposeViaOData in GIDesign INSERT"
+    )
+    # Verify the INSERT INTO GIDesign line contains the GI name
+    assert f"'{gi_name}'" in sql, (
+        f"{gi_name} SQL script doesn't reference its own name in GIDesign INSERT"
     )
 
 
-@pytest.mark.parametrize("screen_id", sorted(EXPECTED_GIS.keys()))
-def test_drp_gi_has_required_result_fields(drp_gi_rows, screen_id):
-    """Every DRP GI surfaces the result fields Wave 4 code depends on."""
-    _, _, required_fields = EXPECTED_GIS[screen_id]
-    row = drp_gi_rows[screen_id]
-    result_fields = {r.get("Field") for r in row.iter("GIResult")}
-    missing = required_fields - result_fields
+@pytest.mark.parametrize("gi_name", sorted(EXPECTED_GIS.keys()))
+def test_drp_gi_sql_has_no_screenid(sql_scripts, gi_name):
+    """DRP GIs must NOT have ScreenID — this is what makes OData work without 403."""
+    sql = sql_scripts.get(gi_name, "")
+    # Check the GIDesign INSERT specifically — ScreenID should not appear as a column
+    gi_design_match = re.search(
+        r"INSERT\s+INTO\s+GIDesign\s*\(([^)]+)\)", sql, re.IGNORECASE
+    )
+    assert gi_design_match, f"{gi_name} SQL script missing INSERT INTO GIDesign"
+    columns = gi_design_match.group(1)
+    assert "ScreenID" not in columns, (
+        f"{gi_name} SQL script has ScreenID in GIDesign INSERT columns — "
+        f"this will trigger SiteMap access checks and break OData"
+    )
+
+
+@pytest.mark.parametrize("gi_name", sorted(EXPECTED_GIS.keys()))
+def test_drp_gi_sql_has_tables(sql_scripts, gi_name):
+    """Every DRP GI SQL script references the expected table aliases."""
+    expected_aliases, _ = EXPECTED_GIS[gi_name]
+    sql = sql_scripts.get(gi_name, "")
+    for alias in expected_aliases:
+        assert f"'{alias}'" in sql, (
+            f"{gi_name} SQL script missing table alias '{alias}'"
+        )
+
+
+@pytest.mark.parametrize("gi_name", sorted(EXPECTED_GIS.keys()))
+def test_drp_gi_sql_has_required_result_fields(sql_scripts, gi_name):
+    """Every DRP GI SQL script includes the required result fields."""
+    _, required_fields = EXPECTED_GIS[gi_name]
+    sql = sql_scripts.get(gi_name, "")
+    missing = set()
+    for field in required_fields:
+        if f"'{field}'" not in sql:
+            missing.add(field)
     assert not missing, (
-        f"{screen_id} missing required result fields: {sorted(missing)}. "
-        f"Present: {sorted(result_fields)}"
+        f"{gi_name} SQL script missing required result fields: {sorted(missing)}"
     )
 
 
-@pytest.mark.parametrize("screen_id", sorted(EXPECTED_GIS.keys()))
-def test_drp_gi_has_sitemap_entry(drp_gi_rows, screen_id):
-    """Every DRP GI has a SiteMap row so it shows up in the Container Tracking workspace."""
-    row = drp_gi_rows[screen_id]
-    sitemap_rows = row.findall("./SiteMap/row")
-    assert len(sitemap_rows) >= 1, f"{screen_id} missing <SiteMap> entry"
-    sm_row = sitemap_rows[0]
-    assert sm_row.get("ScreenID") == screen_id, (
-        f"{screen_id} SiteMap row has ScreenID={sm_row.get('ScreenID')}"
-    )
-    # Parent should be the shared Container Tracking workspace folder
-    assert sm_row.get("ParentID") == "9c89e3db-7c47-43c0-8554-5d2c9f2c0e87", (
-        f"{screen_id} SiteMap ParentID mismatch — should match other SB401xxx GIs"
+def test_drp_gi_xml_blocks_removed():
+    """No DRP GIs should remain as XML GenericInquiryScreen blocks."""
+    content = PROJECT_XML.read_text(encoding="utf-8")
+    cleaned = re.sub(r"<%--.*?--%>", "", content, flags=re.DOTALL)
+    root = ET.fromstring(cleaned)
+
+    drp_names_in_xml = []
+    for row in root.iter("row"):
+        name = row.get("Name", "")
+        if name.startswith("DRP_") and row.get("DesignID"):
+            drp_names_in_xml.append(name)
+
+    assert not drp_names_in_xml, (
+        f"DRP GIs still defined as XML blocks (should be SQL-only): "
+        f"{drp_names_in_xml}"
     )
 
 
 def test_probe_gis_include_drp_phase0():
-    """validate_publish_gi.PROBE_GIS covers the 3 new DRP GIs so post-deploy
+    """validate_publish_gi.PROBE_GIS covers all 5 DRP GIs so post-deploy
     verification catches regressions automatically."""
     import sys
     import os
@@ -159,7 +185,7 @@ def test_probe_gis_include_drp_phase0():
     )
     from validate_publish_gi import PROBE_GIS  # type: ignore
 
-    expected_names = {name for name, _, _ in EXPECTED_GIS.values()}
+    expected_names = set(EXPECTED_GIS.keys())
     missing = expected_names - set(PROBE_GIS)
     assert not missing, (
         f"DRP Phase 0 GIs missing from PROBE_GIS: {sorted(missing)}. "


### PR DESCRIPTION
## Summary

- Replace 5 DRP Generic Inquiry XML `<GenericInquiryScreen>` blocks with SQL installer `<Sql>` scripts following the proven StudioBAuditTrail pattern — no ScreenID, no SiteMap entries — which eliminates Acumatica's screen-level access check that caused 403/404 on OData
- Remove `EnsureDRPGISiteMap` from `AesthetikContainersInstall.cs` (was re-adding ScreenID/SiteMap, conflicting with the fix)
- Add `DRP_ItemWarehouseSettings` to PROBE_GIS and test coverage (was previously missing)

## Background

The 5 DRP GIs (VelocityHistory, OpenSOCommitments, InventoryBySite, OpenPOLines, ItemWarehouseSettings) returned 403/404 on OData because `merge=true` publish didn't reliably persist `RolesInGraph` entries from XML. The ScreenIDs (SB401080–SB401120) triggered Acumatica's screen-level access check, and the SiteMap entries were never properly applied.

Proof: `StudioBAuditTrail` in StudioBAcuOps is SQL-installed with no ScreenID/SiteMap and returns 200 on OData.

## Changes

| File | Change |
|------|--------|
| `Customization/AesthetikContainers/project.xml` | +5 SQL installer scripts, −EnableOData script, −4 GenericInquiryScreen blocks (746 lines), −4 ScreenWithRights entries |
| `src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs` | Remove `EnsureDRPGISiteMap` method and call |
| `tests/test_drp_phase0_gis.py` | Rewrite: verify SQL scripts instead of XML blocks (32 tests, all 5 GIs) |
| `scripts/heritage/validate_publish_gi.py` | Add `DRP_ItemWarehouseSettings` to `PROBE_GIS` |

## Test plan

- [x] `pytest tests/test_drp_phase0_gis.py -v` — 32/32 passed
- [ ] After deploy, probe OData with Basic Auth — all 5 GIs should return 200
- [ ] Verify no `ScreenID` in GIDesign rows for DRP GIs in DB

https://claude.ai/code/session_01Y5QvFtGkNWoimPZzhDdTJP