### PR TITLE
fix: remove invalid ASP.NET comment breaking XML validation

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -436,7 +436,6 @@ VALUES
     (@CompanyID, @DesignID, 2, 'INSite.SiteCD', 0);
 ]]></CDATA>
     </Sql>
-    <%-- AesthetikContainers_SchemaDiscovery_v1 removed — diagnostic only, not needed in CI --%>
     <Page path="~/pages/po/po301000.aspx">
         <PXFormView ID="form" ParentId="phF_form" TypeFullName="PX.Web.UI.PXFormView">
             <Children Key="Template">


### PR DESCRIPTION
## Summary

- PR #427 left a `<%-- --%>` ASP.NET comment at line 439 of `project.xml` which is not valid XML
- Pipeline validator fails with `not well-formed (invalid token): line 439, column 5`
- Fix: delete the comment line

## Test plan

- [x] `python -c "import xml.etree.ElementTree as ET; ET.parse('Customization/AesthetikContainers/project.xml')"` — passes
- [ ] CI pipeline passes validation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)