### PR TITLE
fix: remove PXLotSertialNbrAttributeExtPkg from co_publish

### DIFF
--- a/acuops.yaml
+++ b/acuops.yaml
@@ -27,7 +27,6 @@ publish:
     - "AesthetikWMS"
     - "AsthetikTheme"
     - "StudioBAcuOps"
-    - "PXLotSertialNbrAttributeExtPkg"
   poll_interval: 10
   poll_timeout: 600
 


### PR DESCRIPTION
## Summary

- Remove `PXLotSertialNbrAttributeExtPkg` from `co_publish` in acuops.yaml
- Stock Acumatica extension stays published via `merge=true` without being listed
- Reduces ASPX page count for `PXPageIndexingService`, preventing publish timeouts
- Previous deploy (run 24493876870) failed at ~120s with partial state — 3 of 5 DRP SQL installers never executed

## Context

Rule 22: keep co-publish to Aesthetik-owned projects only. The 2026-04-15 outage and tonight's partial publish both correlate with inflated co-publish lists.

## Test plan

- [ ] Deploy completes under 120s timeout
- [ ] All 5 DRP GIs return HTTP 200 on OData after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)