### PR TITLE
fix: remove invalid secrets: inherit from workflow_call trigger

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -113,7 +113,6 @@ on:
         type: string
         required: false
         default: ''
-    secrets: inherit
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`workflow_dispatch` of acuops-build.yml returned HTTP 422: \`Unexpected value 'inherit'\` at line 116.

Root cause: \`secrets: inherit\` was incorrectly placed inside the called workflow's \`workflow_call:\` trigger block. It belongs on the CALLING workflow's \`uses:\` block.

## Fix

Remove the \`secrets: inherit\` line from acuops-deploy.yml's \`workflow_call:\` declaration. The caller (acuops-build.yml \`call-deploy\` job) already has it correctly placed.

## Test plan
- [ ] \`gh workflow run acuops-build.yml --ref main\` succeeds (no HTTP 422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)