### PR TITLE
fix: re-xfail 3 SB501000 tests with accurate root-cause reasons

### DIFF
--- a/tests/ui/test_pcc_verify.py
+++ b/tests/ui/test_pcc_verify.py
@@ -82,6 +82,13 @@ class TestPCCBugFixes:
                 f"Detail panel did not sync on 3rd click: still shows '{second_container}'"
             )
 
+    @pytest.mark.xfail(
+        reason="PR #366 residual bug: risk aggregation counts always zero. "
+        "Iframe read works (read_html_view confirms content); but ACTION/WATCH/"
+        "CLEAR bucket counts all render as 0. RowSelected<ContainerFilter> "
+        "doc count logic not producing non-zero values. Tracked for separate fix.",
+        strict=False,
+    )
     def test_kpi_tiles_show_counts(self, acumatica_screen):
         """Bug 3: KPI tiles should show non-zero counts for ACTION/WATCH/CLEAR.
 
@@ -110,6 +117,15 @@ class TestPCCBugFixes:
             "Bug 3 (real doc counts in risk aggregation) may not be fixed."
         )
 
+    @pytest.mark.xfail(
+        reason="PR #366 residual bug: htmlKPITiles outer element has 0px "
+        "computed height on sandbox. The Height=280px change from PR #366 "
+        "isn't reaching the rendered DOM — likely ASPX attribute not applied "
+        "or parent container overflow clipping. Not an iframe issue — our "
+        "read_html_view fix confirmed inner content loads. Tracked for "
+        "separate fix.",
+        strict=False,
+    )
     def test_metrics_row_visible(self, acumatica_screen):
         """Bug 2: Metrics row should be visible below KPI tiles.
 
@@ -163,6 +179,16 @@ class TestPCCDateFields:
         "edPaymentDueDate",
     ]
 
+    @pytest.mark.xfail(
+        reason="PR #366 residual bug: all 8 Shipping & Delivery date fields "
+        "(edCargoReadyDate, edFactoryPickupDate, edOnBoardDate, "
+        "edShipmentWindowStart/End, edDrayageAppointmentDate, "
+        "edDeliveryOrderDate, edPaymentDueDate) missing from rendered DOM "
+        "even after clicking a grid row to populate frmDetail. Either "
+        "ASPX declarations missing, DAC extensions missing, or fields in "
+        "a tab/group that doesn't render. Tracked for separate fix.",
+        strict=False,
+    )
     def test_shipping_delivery_fields_exist(self, acumatica_screen):
         """All 8 new Shipping & Delivery date fields should be in the DOM.
 


### PR DESCRIPTION
## Summary

Run [24533224543](https://github.com/studio-b-ai/acumatica-ci-cd/actions/runs/24533224543) validated PR #434's test infrastructure fixes:

- ✅ \`test_grid_has_add_button\` — broadened selector worked
- ✅ \`test_stock_item_base_uom_is_yds\` — 3s wait fixed timing
- ⏭️ \`test_detail_panel_syncs\` — SKIPPED (no test data, expected)

But 3 tests still fail — **for different reasons than the original xfails**. The test infrastructure is now correct; these are real underlying bugs from PR #366.

| Test | Original xfail | Actual issue found |
|------|---------------|-------------------|
| \`test_kpi_tiles_show_counts\` | "iframe read returns empty" | Iframe reads OK. Counts all zero. |
| \`test_metrics_row_visible\` | "height 0px on sandbox" | Still 0px — not an iframe issue |
| \`test_shipping_delivery_fields_exist\` | "fields missing from DOM" | Still missing even after row click |

## Action taken

Re-xfail with accurate root-cause descriptions so the xfails point at real bugs for triage. A separate task will fix the underlying SB501000 issues.

## Why merge now

PCC has been broken on prod since 2026-04-15. DRP GI deploy (PR #431) is the vehicle to re-publish and restore ASPX indexing. These 3 bugs are pre-existing, non-P0, and don't block PCC recovery.

## Test plan
- [x] sandbox-gate validation in run 24533224543 completed — confirmed which tests pass vs fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)