### PR TITLE
fix: restore notify.py --recipients guard after pipeline split

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -769,15 +769,25 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          NOTIFY_RECIPIENTS: ${{ vars.NOTIFY_RECIPIENTS }}
+          NOTIFY_SENDER: ${{ vars.NOTIFY_SENDER }}
         run: |
-          if [ -f pipeline/scripts/notify.py ]; then
+          # notify.py requires --recipients; skip entirely if not configured.
+          # The build job used to expose notify_recipients/notify_sender as
+          # outputs but they were never actually wired up (broken since before
+          # the pipeline split). GitHub Variables are the new source of truth.
+          if [ -f pipeline/scripts/notify.py ] && [ -n "${NOTIFY_RECIPIENTS}" ]; then
             python pipeline/scripts/notify.py \
               --type countdown \
               --minutes 20 \
+              --recipients "${NOTIFY_RECIPIENTS}" \
+              --sender "${NOTIFY_SENDER}" \
               --project "${{ inputs.project_name }}" \
               --environment "${{ steps.env.outputs.target }}" \
               --slack-webhook "${SLACK_WEBHOOK_URL}" \
               ${{ steps.hours.outputs.after_hours == 'true' && '--skip-email' || '' }}
+          else
+            echo "Skipping notify — NOTIFY_RECIPIENTS var not set"
           fi
 
       # ── Pre-deploy smoke test ────────────────────────────────────────
@@ -1101,14 +1111,20 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          NOTIFY_RECIPIENTS: ${{ vars.NOTIFY_RECIPIENTS }}
+          NOTIFY_SENDER: ${{ vars.NOTIFY_SENDER }}
         run: |
-          if [ -f pipeline/scripts/notify.py ]; then
+          if [ -f pipeline/scripts/notify.py ] && [ -n "${NOTIFY_RECIPIENTS}" ]; then
             python pipeline/scripts/notify.py \
               --type online \
+              --recipients "${NOTIFY_RECIPIENTS}" \
+              --sender "${NOTIFY_SENDER}" \
               --project "${{ inputs.project_name }}" \
               --environment "${{ steps.env.outputs.target }}" \
               --slack-webhook "${SLACK_WEBHOOK_URL}" \
               ${{ steps.hours.outputs.after_hours == 'true' && '--skip-email' || '' }}
+          else
+            echo "Skipping notify — NOTIFY_RECIPIENTS var not set"
           fi
 
       - name: Notify deploy failed
@@ -1119,14 +1135,20 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          NOTIFY_RECIPIENTS: ${{ vars.NOTIFY_RECIPIENTS }}
+          NOTIFY_SENDER: ${{ vars.NOTIFY_SENDER }}
         run: |
-          if [ -f pipeline/scripts/notify.py ]; then
+          if [ -f pipeline/scripts/notify.py ] && [ -n "${NOTIFY_RECIPIENTS}" ]; then
             python pipeline/scripts/notify.py \
               --type failed \
+              --recipients "${NOTIFY_RECIPIENTS}" \
+              --sender "${NOTIFY_SENDER}" \
               --project "${{ inputs.project_name }}" \
               --environment "${{ steps.env.outputs.target }}" \
               --slack-webhook "${SLACK_WEBHOOK_URL}" \
               ${{ steps.hours.outputs.after_hours == 'true' && '--skip-email' || '' }}
+          else
+            echo "Skipping notify — NOTIFY_RECIPIENTS var not set"
           fi
 
       # ── Auto-lockout on deploy failure ───────────────────────────────


### PR DESCRIPTION
## Summary

Run 24534950956 (skip_sandbox_gate prod deploy) failed at \`Send maintenance countdown warnings\` with:
\`\`\`
notify.py: error: the following arguments are required: --recipients
\`\`\`

Root cause: during pipeline split (PR #433), the broken \`needs.build.outputs.notify_recipients\` reference was removed but the \`-n "\${NOTIFY_RECIPIENTS}"\` guard was also dropped. notify.py requires \`--recipients\` to be non-empty.

## Fix

Restore the guard across all 3 notify steps (countdown, online, failed). Pull recipient/sender from GitHub Variables (\`vars.NOTIFY_RECIPIENTS\`, \`vars.NOTIFY_SENDER\`). If vars aren't set, step logs a skip message and continues.

## Urgency

PCC broken on prod since 2026-04-15. The deploy step (\`Import and publish customization\`) was SKIPPED because the notify step failed before it — app pool NOT restarted yet. This fix unblocks the deploy.

## Test plan
- [ ] Fresh dispatch with same overrides (skip_sandbox_gate + force_business_hours + i_really_mean_it) reaches the publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)