### PR TITLE
fix(pcc): resolve 3 residual SB501000 bugs from PR #366

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -128,7 +128,10 @@
                 <px:PXDateTimeEdit ID="edFactoryPromisedDate" runat="server" DataField="FactoryPromisedDate" />
                 <px:PXDateTimeEdit ID="edFactoryActualDate" runat="server" DataField="FactoryActualDate" />
                 <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
+                <px:PXDateTimeEdit ID="edFactoryPickupDate" runat="server" DataField="FactoryPickupDate" />
                 <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />
+                <px:PXDateTimeEdit ID="edShipmentWindowStart" runat="server" DataField="ShipmentWindowStart" />
+                <px:PXDateTimeEdit ID="edShipmentWindowEnd" runat="server" DataField="ShipmentWindowEnd" />
                 <px:PXDateTimeEdit ID="edDrayageAppointmentDate" runat="server" DataField="DrayageAppointmentDate" />
                 <px:PXTextEdit ID="edDeliveryOrderNbr" runat="server" DataField="DeliveryOrderNbr" />
                 <px:PXDateTimeEdit ID="edDeliveryOrderDate" runat="server" DataField="DeliveryOrderDate" />

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -344,7 +344,10 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                 <px:PXDateTimeEdit ID="edFactoryPromisedDate" runat="server" DataField="FactoryPromisedDate" />
                 <px:PXDateTimeEdit ID="edFactoryActualDate" runat="server" DataField="FactoryActualDate" />
                 <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
+                <px:PXDateTimeEdit ID="edFactoryPickupDate" runat="server" DataField="FactoryPickupDate" />
                 <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />
+                <px:PXDateTimeEdit ID="edShipmentWindowStart" runat="server" DataField="ShipmentWindowStart" />
+                <px:PXDateTimeEdit ID="edShipmentWindowEnd" runat="server" DataField="ShipmentWindowEnd" />
                 <px:PXDateTimeEdit ID="edDrayageAppointmentDate" runat="server" DataField="DrayageAppointmentDate" />
                 <px:PXTextEdit ID="edDeliveryOrderNbr" runat="server" DataField="DeliveryOrderNbr" />
                 <px:PXDateTimeEdit ID="edDeliveryOrderDate" runat="server" DataField="DeliveryOrderDate" />

--- a/tests/ui/test_pcc_verify.py
+++ b/tests/ui/test_pcc_verify.py
@@ -179,38 +179,29 @@ class TestPCCDateFields:
         "edPaymentDueDate",
     ]
 
-    @pytest.mark.xfail(
-        reason="PR #366 residual bug: all 8 Shipping & Delivery date fields "
-        "(edCargoReadyDate, edFactoryPickupDate, edOnBoardDate, "
-        "edShipmentWindowStart/End, edDrayageAppointmentDate, "
-        "edDeliveryOrderDate, edPaymentDueDate) missing from rendered DOM "
-        "even after clicking a grid row to populate frmDetail. Either "
-        "ASPX declarations missing, DAC extensions missing, or fields in "
-        "a tab/group that doesn't render. Tracked for separate fix.",
-        strict=False,
-    )
     def test_shipping_delivery_fields_exist(self, acumatica_screen):
         """All 8 new Shipping & Delivery date fields should be in the DOM.
 
-        The detail form (frmDetail) on SB501000 renders below the grid.
-        Click a grid row first to ensure Current is populated and the
-        detail form has rendered its fields.
+        The detail form (frmDetail) lives inside a LoadOnDemand SmartPanel —
+        content is not in the DOM until the panel is opened. Opening the
+        panel requires firing the OpenContainerDetail callback, which is
+        wired to the ContainerCD column's LinkCommand. Clicking the
+        ContainerCD <a> in a grid row triggers it.
         """
         screen = acumatica_screen("SB501000")
         screen.page.wait_for_timeout(3000)
 
-        # Click the first grid row to populate frmDetail (fields may not
-        # render until a container is selected)
-        rows = screen.locator("[id*='gridContainers'] tr.GridRow")
-        if rows.count() > 0:
-            rows.first.click(force=True)
-            screen.page.wait_for_timeout(3000)
-        else:
-            # Fallback: navigate to last record
-            last_btn = screen.locator("div[icon='Last'], [id*='btnLast']").first
-            if last_btn.is_visible(timeout=3000):
-                last_btn.click()
-                screen.page.wait_for_timeout(3000)
+        # Acumatica grid data rows use id='..._row_N' and have no class —
+        # the legacy 'tr.GridRow' selector never matches.
+        rows = screen.locator("tr[id*='gridContainers_row_']")
+        if rows.count() == 0:
+            pytest.skip("Sandbox grid has no containers")
+
+        # Click the ContainerCD link to open the LoadOnDemand SmartPanel.
+        # The first <a> in the row is the ContainerCD cell (first column
+        # with LinkCommand='OpenContainerDetail').
+        rows.first.locator("a").first.click()
+        screen.page.wait_for_timeout(3000)
 
         missing = []
         for field_id in self.SHIPPING_DELIVERY_FIELDS:

--- a/tests/ui/test_pcc_verify.py
+++ b/tests/ui/test_pcc_verify.py
@@ -117,15 +117,6 @@ class TestPCCBugFixes:
             "Bug 3 (real doc counts in risk aggregation) may not be fixed."
         )
 
-    @pytest.mark.xfail(
-        reason="PR #366 residual bug: htmlKPITiles outer element has 0px "
-        "computed height on sandbox. The Height=280px change from PR #366 "
-        "isn't reaching the rendered DOM — likely ASPX attribute not applied "
-        "or parent container overflow clipping. Not an iframe issue — our "
-        "read_html_view fix confirmed inner content loads. Tracked for "
-        "separate fix.",
-        strict=False,
-    )
     def test_metrics_row_visible(self, acumatica_screen):
         """Bug 2: Metrics row should be visible below KPI tiles.
 
@@ -139,9 +130,13 @@ class TestPCCBugFixes:
         screen = acumatica_screen("SB501000")
         screen.page.wait_for_timeout(3000)
 
-        # Check the htmlKPITiles outer element has sufficient height
+        # Check the htmlKPITiles outer element has sufficient height.
+        # Use [id$="htmlKPITiles"] (ends-with) to target the rendered TABLE
+        # element directly — [id*="htmlKPITiles"] (contains) also matches
+        # the hidden '..._state' INPUT that PXHtmlView emits first in DOM
+        # order, which has offsetHeight=0 and would mask the real height.
         height = screen.evaluate(
-            "() => { const el = document.querySelector('[id*=\"htmlKPITiles\"]'); "
+            "() => { const el = document.querySelector('[id$=\"htmlKPITiles\"]'); "
             "if (!el) return 0; "
             "return el.offsetHeight || parseInt(el.style.height) || 0; }"
         )

--- a/tests/ui/test_pcc_verify.py
+++ b/tests/ui/test_pcc_verify.py
@@ -82,18 +82,17 @@ class TestPCCBugFixes:
                 f"Detail panel did not sync on 3rd click: still shows '{second_container}'"
             )
 
-    @pytest.mark.xfail(
-        reason="PR #366 residual bug: risk aggregation counts always zero. "
-        "Iframe read works (read_html_view confirms content); but ACTION/WATCH/"
-        "CLEAR bucket counts all render as 0. RowSelected<ContainerFilter> "
-        "doc count logic not producing non-zero values. Tracked for separate fix.",
-        strict=False,
-    )
     def test_kpi_tiles_show_counts(self, acumatica_screen):
-        """Bug 3: KPI tiles should show non-zero counts for ACTION/WATCH/CLEAR.
+        """KPI tiles should reflect real container data in RowSelected<ContainerFilter>.
 
-        After adding real doc counts to RowSelected<ContainerFilter>,
-        the risk aggregation should produce non-zero bucket counts.
+        The PIPELINE tile always renders an '{N} ACTIVE CONTAINERS' sublabel
+        regardless of LATE/AT-RISK criteria, so it's the most reliable
+        signal that the graph's aggregation handler ran and counted real
+        containers. The legacy regex `>(\\d+)<` only matched the LATE
+        count's `>{N}</div>` pattern — AT RISK renders `>$N<` ($ breaks
+        \\d) and pipeline counts like `BOOKED 0 · IN TRANSIT 1` are bare
+        text with no `>N<` boundary, so the old test would fail any time
+        sandbox had active-but-on-time containers.
 
         PXHtmlView renders content inside iframe.htmlviewinner — must
         use read_html_view_html() to traverse into the inner iframe.
@@ -101,20 +100,21 @@ class TestPCCBugFixes:
         screen = acumatica_screen("SB501000")
         screen.page.wait_for_timeout(3000)
 
-        # Read the KPI tiles HTML from the inner htmlviewinner iframe
         kpi_html = screen.read_html_view_html("htmlKPITiles")
-
         assert kpi_html, "KPI tiles HTML is empty — htmlKPITiles iframe not rendering"
 
-        # Check that at least one tile shows a non-zero count
-        # The tiles render as HTML with count values — at least one should be > 0
-        # since we have known containers in sandbox
         import re
-        numbers = re.findall(r'>(\d+)<', kpi_html)
-        total = sum(int(n) for n in numbers if n.isdigit())
-        assert total > 0, (
-            f"All KPI tile counts are zero. Extracted numbers: {numbers}. "
-            "Bug 3 (real doc counts in risk aggregation) may not be fixed."
+        active_match = re.search(r"(\d+)\s+ACTIVE\s+CONTAINERS", kpi_html, re.I)
+        assert active_match, (
+            "PIPELINE tile did not render '{N} ACTIVE CONTAINERS' sublabel — "
+            "RowSelected<ContainerFilter> may not have fired or ContainerKPITileBuilder "
+            f"is producing unexpected markup. First 500 chars:\n{kpi_html[:500]}"
+        )
+        active_count = int(active_match.group(1))
+        assert active_count > 0, (
+            f"PIPELINE tile shows 0 ACTIVE CONTAINERS — expected sandbox to have "
+            "at least one non-terminal container (status != Delivered/Cancelled) "
+            "so the graph's aggregation loop produces a non-zero count."
         )
 
     def test_metrics_row_visible(self, acumatica_screen):


### PR DESCRIPTION
## Summary

Closes the 3 re-xfailed tests in `tests/ui/test_pcc_verify.py` (PR #436 xfails) by fixing their root causes. Per CLAUDE.md rule 20, every failure was first reproduced against the live sandbox via Playwright before proposing a fix — verification showed **one real customization bug and two test bugs** that look identical in a pytest log but have different fixes.

Supersedes PR #437 (which partially addressed Bug 3 correctly but used test-evasion for Bugs 1 & 2).

### Bug 3 — `test_shipping_delivery_fields_exist` (real customization bug)
3 of 8 `PXDateTimeEdit` controls were missing from the `frmDetail` Dates group on `SB501000.aspx`: `edFactoryPickupDate`, `edShipmentWindowStart`, `edShipmentWindowEnd`. DAC fields exist in `UsrContainer` (added 2026-04-12) but controls were never wired. Also fixed the test to use the correct Acumatica row selector (`tr[id*='gridContainers_row_']` — Acumatica data rows have an `id` but no `class`, so the legacy `tr.GridRow` never matched) and to click the `ContainerCD` link to fire `OpenContainerDetail`, since `frmDetail` lives inside a `LoadOnDemand` SmartPanel whose content isn't in the DOM until the panel opens.

### Bug 2 — `test_metrics_row_visible` (test bug)
Test used `document.querySelector('[id*=\"htmlKPITiles\"]')`, which first matches the hidden `..._state` INPUT that PXHtmlView emits alongside the rendered TABLE. The INPUT's `offsetHeight` is 0 regardless of the control's declared Height. Sandbox probe confirmed the actual TABLE renders at `offsetHeight=280px`, matching the ASPX `Height=\"280px\"`. Changed selector to `[id$=\"htmlKPITiles\"]` (ends-with) to target the TABLE directly, matching the convention `read_html_view()` already uses.

### Bug 1 — `test_kpi_tiles_show_counts` (test bug)
Assertion used regex `>(\d+)<` to sum every digit-run wrapped in `>...<` across the KPI tile HTML. That only matches the LATE tile's `>{N}</div>` pattern — AT RISK renders `>$N<` (the `\$` breaks `\d+`) and pipeline counts render as bare text like `BOOKED 0 · IN TRANSIT 1<br/>` with no `>N<` boundary. Whenever sandbox had active containers but none were LATE (the common case), the sum was 0 and the test failed even though `RowSelected<ContainerFilter>` was doing the right thing. Sandbox probe confirmed: 7 ACTIVE CONTAINERS with LATE=0, AT RISK=\$0 — graph is fine. New assertion anchors on the PIPELINE tile's `{N} ACTIVE CONTAINERS` sublabel, which `ContainerKPITileBuilder` emits unconditionally, directly verifying the aggregation loop ran on real data.

## Commit history

- `17208cb` — fix(pcc): add 3 missing Shipping & Delivery date controls to SB501000
- `0103d28` — fix(pcc): test_metrics_row_visible uses ends-with selector for KPI height
- `12352c4` — fix(pcc): test_kpi_tiles_show_counts asserts PIPELINE ACTIVE CONTAINERS

## Sandbox verification (Playwright, 2026-04-16)

| Symptom | Finding |
|---|---|
| `gridContainers tr.GridRow` row count | 0 (selector wrong — Acumatica uses `id='..._row_N'`) |
| Actual grid row count | 15 (visible as `ctl00_phG_gridContainers_row_N`) |
| `[id*='htmlKPITiles']` first match | `INPUT#..._state`, `offsetHeight=0` |
| `[id$='htmlKPITiles']` first match | `TABLE#..._htmlKPITiles`, `offsetHeight=280` |
| KPI iframe text | `7 ACTIVE CONTAINERS / BOOKED 0 · IN TRANSIT 1 / AT PORT 0 · CUSTOMS 6` + `OPEN PO VALUE \$205,132 / 49% CROSS-DOCK / \$104,185 UNCOVERED` |
| 8 Shipping & Delivery fields after ContainerCD link click | 5 present (3 each), 3 missing (`edFactoryPickupDate`, `edShipmentWindowStart`, `edShipmentWindowEnd`) |

## Deploy impact

Only the ASPX change (Bug 3) requires an Acumatica publish. Bugs 1 & 2 are test-only and can be verified on the sandbox immediately once this branch deploys through sandbox-gate. Per rule 11, merge should happen in-window (after 6 PM ET or weekend); these bugs are non-P0.

## Test plan

- [ ] Sandbox-gate: `test_shipping_delivery_fields_exist` passes against sandbox post-deploy (new ASPX controls rendered)
- [ ] Sandbox-gate: `test_metrics_row_visible` passes (TABLE offsetHeight=280 via ends-with selector)
- [ ] Sandbox-gate: `test_kpi_tiles_show_counts` passes (PIPELINE ACTIVE CONTAINERS > 0 from real sandbox data)
- [ ] No regression in unchanged tests in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)