### PR TITLE
fix(ci): unbreak require-review-label gate — remove comments from case block

### DIFF
--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -65,27 +65,26 @@ jobs:
 
           SENSITIVE=0
           HITS=""
+          # Groups (in order below): Acumatica customization packages; DB migrations;
+          # raw SQL; Acumatica + gateway clients; container + Railway deploy;
+          # CI/CD workflows; deploy / publish scripts. See top-of-file docstring
+          # for the authoritative description of each group.
+          # NOTE: do NOT place `# comment` lines between patterns in the case block —
+          # comments terminate the `\` line continuation and cause a bash syntax error.
           while IFS= read -r FILE; do
             [ -z "$FILE" ] && continue
             case "$FILE" in
-              # Acumatica customization packages
               Customization/*|Customization-staging/*|*/Customization/*|\
-              # DB migrations
               src/migrations/*|migrations/*|packages/*/migrations/*|\
               prisma/schema.prisma|packages/*/prisma/schema.prisma|\
-              # Raw SQL anywhere
               *.sql|\
-              # Acumatica + gateway clients
               src/lib/acumatica*|src/**/acumatica*|\
               packages/*/src/**/acumatica*|\
               src/**/acu*-client.ts|src/**/acuops-agent.ts|\
               packages/*/src/**/acu*-client.ts|\
-              # Container + Railway deploy
               Dockerfile*|railway.json|railway.toml|\
               packages/*/Dockerfile*|packages/*/railway.json|packages/*/railway.toml|\
-              # CI/CD workflows
               .github/workflows/*|\
-              # Deploy / publish scripts
               scripts/deploy*|scripts/publish*|scripts/import*)
                 SENSITIVE=1
                 HITS="$HITS $FILE"


### PR DESCRIPTION
## Summary

- **Bug:** `Detect sensitive-path changes` step in `.github/workflows/require-review-label.yml` had `# comment` lines interleaved with `\` line-continuations inside a `case` block. Comments terminate the `\` continuation, so bash aborts with `syntax error near unexpected token 'newline'`. Every PR since the file landed failed this check.
- **Fix:** Moved group descriptions out of the `case` body into a preamble block; the top-of-file docstring already has the authoritative map. Patterns remain as-is, with `\` continuations kept (plain trailing `|` without backslash does **not** work in bash `case` — verified locally on bash 3.2.57).
- **Repro:** Failed run `24544015735` on PR #442.

## Test plan

- [x] Local bash repro: pre-fix block fails with `syntax error near unexpected token 'newline'`; post-fix block runs clean.
- [x] Local bash harness with mixed paths: sensitive paths (`Customization/**`, `.github/workflows/**`, `*.sql`, `scripts/deploy*`, `Dockerfile*`, `src/lib/acumatica*`) correctly matched; non-sensitive paths (`tests/**`, `README.md`, `docs/plans/**`) correctly skipped.
- [ ] After merge: open a throwaway PR touching a **non-sensitive** path (e.g. `tests/`) and confirm the gate **passes**.
- [ ] After merge: open a throwaway PR touching a **sensitive** path (e.g. another tweak under `.github/workflows/`) without the `reviewed` label and confirm the gate **fails**, then add the label and confirm it **passes**.

## Note on this PR itself

This PR touches `.github/workflows/**` (sensitive), so the gate runs against the **PR branch** — i.e. against the fixed version of itself. That version should pass once you apply the `reviewed` label. If the branch-protection status check isn't wired up yet (per line 33–35 of the file docstring), you can merge without needing it.

## Follow-ups (out of scope for this PR)

- **Branch protection**: the workflow's own comment notes this gate is not yet in required status checks on `main`. Once the syntax is verified fixed via the test-plan PRs above, consider adding "Require review label" to the required checks on the `main` branch protection rule (Settings → Branches → Edit `main` → Required status checks). Settings change — proposing, not executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)