### PR TITLE
ci: wire auto-qualify on Customization PRs

### DIFF
--- a/.github/workflows/pr-auto-qualify.yml
+++ b/.github/workflows/pr-auto-qualify.yml
@@ -1,0 +1,36 @@
+name: Auto-qualify customization PRs
+
+# Triggers on every PR that touches Customization/**. Calls the reusable
+# auto-qualify workflow in acuops-pipeline, which runs validate-project.py
+# + qualify.py + ui-test-suite @acumatica and — on all-pass — applies the
+# `reviewed` label to this PR so it can merge without a human click.
+#
+# See studio-b-ai/acuops-pipeline/.github/workflows/auto-qualify.yml for
+# the qualifier logic + expected secrets.
+#
+# Known v1 gap: the reusable workflow takes a single customization_path.
+# acumatica-ci-cd has three packages (AesthetikContainers, AesthetikWMS,
+# StudioBAcuOps). We point at the primary (CUSTOMIZATION_PROJECT_NAME ==
+# AesthetikContainers). PRs that only touch AesthetikWMS or StudioBAcuOps
+# get qualify.py + ui-suite coverage (those run at the tenant level, not
+# per-package) but miss validate-project.py for those two packages.
+# Follow-up: extend auto-qualify.yml to accept multiple paths.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'Customization/**'
+
+jobs:
+  qualify:
+    uses: studio-b-ai/acuops-pipeline/.github/workflows/auto-qualify.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_repo: ${{ github.repository }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      # Pulled from repo vars — set via `gh variable set CUSTOMIZATION_PROJECT_NAME …`
+      # Current value: AesthetikContainers
+      project_name: ${{ vars.CUSTOMIZATION_PROJECT_NAME }}
+      customization_path: Customization/${{ vars.CUSTOMIZATION_PROJECT_NAME }}
+    secrets: inherit


### PR DESCRIPTION
## What this does

Wires the reusable auto-qualify workflow (studio-b-ai/acuops-pipeline#21) into this repo. Every PR touching `Customization/**` gets:

1. `validate-project.py --strict` on the customization's project.xml
2. `qualify.py` — 6-check sandbox gate
3. `ui-test-suite` full `@acumatica` suite

On all-pass → `reviewed` label auto-applied → PR merges without a human click.

On any fail → Slack to `#deployments`, label stays off, human reviews the specific failed gate.

## Trigger

```yaml
on:
  pull_request:
    types: [opened, synchronize]
    paths: ['Customization/**']
```

Once per PR (opened + new commits only — no re-runs on label/comment events).

## Secrets

Inherited from org level (confirmed set by Kevin):
- `GH_PAT_QUALIFIER` — applies `reviewed` label
- `GH_PAT_DISPATCH` — triggers ui-test-suite
- `ACUMATICA_STG_{URL,USER,PASSWORD,TENANT}` — sandbox creds for qualify.py
- `SLACK_WEBHOOK_QUALIFIER` (optional) — failure alert

## Repo variable

- `CUSTOMIZATION_PROJECT_NAME=AesthetikContainers` (already set)

## Known v1 gap

`acumatica-ci-cd` has three packages: `AesthetikContainers`, `AesthetikWMS`, `StudioBAcuOps`. The reusable workflow takes a **single** `customization_path` input. So PRs that only touch `AesthetikWMS` or `StudioBAcuOps` will:

- **Miss:** `validate-project.py --strict` coverage on those specific project.xml files
- **Still get:** `qualify.py` (tenant-level sandbox check) + `ui-test-suite` (tenant-level screen tests)

Follow-up PR on acuops-pipeline will extend `auto-qualify.yml` to accept a list of paths so multi-package repos get full coverage. Tracked separately.

## Test plan

- [ ] Merge — no CI impact on this repo (only the label check may go red since this PR touches `.github/workflows/`)
- [ ] Next real `Customization/**` PR: verify auto-qualify fires, all 3 jobs run, label applies on pass
- [ ] Trigger a deliberate failure (e.g. intentional XML typo) and verify Slack alert fires + label stays off

🤖 Generated with [Claude Code](https://claude.com/claude-code)