### PR TITLE
harden(ci): actionlint guard — would have caught PR #442

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint config — https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# Register custom self-hosted runner labels so actionlint doesn't false-positive
+# on workflows that route to our on-prem Acumatica SDK runner.
+self-hosted-runner:
+  labels:
+    - acumatica-sdk

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,61 @@
+name: Lint workflows
+
+# Runs actionlint (wraps shellcheck) on every PR and push to catch
+# GitHub Actions syntax errors, expression mistakes, and — critically —
+# bash syntax errors inside `run:` blocks. Would have caught PR #442's
+# bash-case-statement syntax bug before it merged.
+#
+# See lessons-learned.md "CI / GitHub Actions (2026-04-17)" section,
+# specifically: "Bash `case` line-continuations break if `# comment`
+# lines sit between patterns."
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install actionlint
+        id: install
+        run: |
+          set -euo pipefail
+          VERSION=1.7.1
+          curl -sL "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /tmp
+          sudo mv /tmp/actionlint /usr/local/bin/actionlint
+          actionlint -version
+
+      - name: Run actionlint
+        id: lint
+        run: |
+          set -euo pipefail
+          # actionlint exits non-zero on any finding.
+          #
+          # We filter shellcheck style/info/warning findings because there's
+          # meaningful preexisting noise across the repo's workflows — but
+          # shellcheck ERRORS (SC1072/SC1073 in particular) stay in scope:
+          # those are the class that caught PR #442's bash-case-statement bug.
+          #
+          # The inputs-count ignore is a compat concession — the repo has one
+          # legacy `workflow_dispatch` with 11 inputs that works in practice.
+          # Track for cleanup separately; don't let it block new-workflow lint.
+          actionlint \
+            -ignore 'shellcheck reported issue in this script: SC[0-9]+:(style|info|warning)' \
+            -ignore 'maximum number of inputs for "workflow_dispatch" event is 10'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -48,14 +48,13 @@ jobs:
           set -euo pipefail
           # actionlint exits non-zero on any finding.
           #
-          # We filter shellcheck style/info/warning findings because there's
-          # meaningful preexisting noise across the repo's workflows — but
-          # shellcheck ERRORS (SC1072/SC1073 in particular) stay in scope:
-          # those are the class that caught PR #442's bash-case-statement bug.
+          # Filtering: style/info/warning severity findings are ignored
+          # (preexisting noise across the repo). Errors stay in scope —
+          # including SC1072/SC1073 which caught PR #442's bash case bug.
           #
-          # The inputs-count ignore is a compat concession — the repo has one
-          # legacy `workflow_dispatch` with 11 inputs that works in practice.
-          # Track for cleanup separately; don't let it block new-workflow lint.
+          # Inputs-count ignore is a compat concession — the repo has one
+          # legacy workflow_dispatch with 11 inputs that works in practice.
+          # Track cleanup separately; do not block new-workflow lint on it.
           actionlint \
             -ignore 'shellcheck reported issue in this script: SC[0-9]+:(style|info|warning)' \
             -ignore 'maximum number of inputs for "workflow_dispatch" event is 10'

--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -172,7 +172,7 @@ jobs:
           git fetch origin "$BASE_REF" --depth=1 --no-tags
           CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
           echo "Changed files in this PR:"
-          printf '  %s\n' $CHANGED
+          echo "$CHANGED"
 
           PROJECT_XMLS=$(printf '%s\n' "$CHANGED" | grep -E '^Customization/[^/]+/project\.xml$' || true)
           MIGRATIONS=$(printf '%s\n' "$CHANGED" | grep -E '^(src/migrations|migrations|packages/[^/]+/migrations)/.*\.sql$' || true)


### PR DESCRIPTION
## Summary

**Rigby Part 2 hardening** for 2026-04-17 session's lessons. Encodes the "bash `case` line-continuations break if `# comment` lines sit between patterns" lesson ([lessons-learned.md — CI / GitHub Actions section](https://github.com/studio-b-ai/acumatica-ci-cd/blob/main/docs/plans/2026-04-17-agentic-review-gate-design.md)) as an automated code guard, per CLAUDE.md Rigby Part 2: "A lesson without a corresponding automated guard is a wish, not a rule."

## What it adds

- **`.github/workflows/actionlint.yml`** — runs [actionlint](https://github.com/rhysd/actionlint) (wraps shellcheck) on every PR touching `.github/workflows/**` and every push to `main`.
- **`.github/actionlint.yaml`** — config declaring `acumatica-sdk` as a self-hosted runner label so actionlint doesn't false-positive on `acuops-build.yml` / `vm-agent.yml`.
- Fixes two shellcheck findings (SC2086/SC2001) in `require-review-label.yml` left over from [PR #446](https://github.com/studio-b-ai/acumatica-ci-cd/pull/446) — cosmetic only.

## Guard verification

Ran the new lint against the pre-fix state of PR #442 (commit before `07289360`):

```
$ actionlint -ignore '…style|info|warning' /tmp/pre-fix-require-review.yml
.github/workflows/require-review-label.yml:59:9:
  shellcheck reported issue in this script: SC1073:error:13:5:
  Couldn't parse this case item. Fix to allow more checks [shellcheck]
.github/workflows/require-review-label.yml:59:9:
  shellcheck reported issue in this script: SC1072:error:14:20:
  Fix any mentioned problems and try again [shellcheck]
rc=1
```

Both SC1073 + SC1072 fire on the exact shape of the original bug. ✅

## Ignore scope — what I'm filtering and why

Two `-ignore` patterns:

1. `shellcheck reported issue in this script: SC[0-9]+:(style|info|warning)` — preexisting style/info/warning noise across the repo's workflows. Real errors (`:error:`) stay in scope — that's the PR #442 class.
2. `maximum number of inputs for "workflow_dispatch" event is 10` — legacy finding on `acuops-build.yml` with 11 inputs. Works in practice; tracked for separate cleanup.

Everything else — real GitHub Actions errors, shellcheck errors, undefined expressions — fails the build.

## Test plan

- [x] Local lint of the two changed files (require-review-label.yml + actionlint.yml) passes.
- [x] Local lint of the full `.github/workflows/` tree passes with the two `-ignore` patterns.
- [x] Local lint of the pre-fix PR #442 state fails with SC1072+SC1073 as expected.
- [ ] CI run on this PR itself must pass (self-test — this PR touches `.github/workflows/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)