### PR TITLE
fix(ci): unblock sandbox gate — resolve UI test 8-min timeout

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -366,7 +366,13 @@ jobs:
           fi
 
       - name: Run core UI tests
-        timeout-minutes: 8
+        # 2026-04-17: bumped 8 → 20. Full suite takes ~11 min (run 24569665633
+        # reached 68% in 7:28 before timing out). Same pattern as PR #362 which
+        # bumped the container-tracking step 20→35 when its suite grew past 20.
+        # pytest-xdist is off the table: the session-scoped `acumatica_page`
+        # fixture (conftest.py) requires a single login — N workers would mean
+        # N concurrent Acumatica sessions and likely API Login Limit hits.
+        timeout-minutes: 20
         env:
           ACUMATICA_URL: ${{ secrets.ACUMATICA_SANDBOX_URL }}
           ACUMATICA_USERNAME: ${{ secrets.ACUMATICA_SANDBOX_USERNAME }}


### PR DESCRIPTION
## Problem

The \`sandbox-gate\` job's **Run core UI tests** step has \`timeout-minutes: 8\`. Every recent prod deploy has hit this wall and forced operators to use \`skip_sandbox_gate=OVERRIDE\` on legitimate deploys — the exact anti-pattern CLAUDE.md rule #19 was written to prevent. Larry agent (PR #452) reached the same diagnosis but couldn't push the workflow change (no \`workflows\` token scope).

Failed runs (all at \`The action 'Run core UI tests' has timed out after 8 minutes\`):
- 24569665633 (2026-04-17T14:20Z) — stopped at 68%
- 24545950669 (2026-04-17T03:20Z)
- 24544069026 (2026-04-17T02:07Z)

## Measurement

From the log of run 24569665633 — the step started at \`14:44:27\` and timed out at \`14:51:55\`:

| Metric | Value |
|---|---|
| Wall time when killed | 7 min 28 s |
| Progress when killed | **68%** |
| Extrapolated full-suite time | **~11 min** |
| Tests that ran | 53 (out of ~78) |
| Tests that never ran | \`test_uom_migration\` (7 tests), tail of \`test_screen_smoke\` |

Time profile inside the step:
- **Fast** (~2–5 s each): most \`test_pcc_verify\`, \`test_po_custom_fields\`, ~half of \`test_screen_smoke\` simple navs
- **Slow** (~30 s each): \`test_auto_allocation\` (4 × 30 s ≈ 2 min), \`AR303020\`/\`CR306x\`/\`IGCM3098\` screen loads (~30 s), \`test_shipping_delivery_fields_exist\` xfail (34 s)
- **Very slow** (~150 s): \`TestStockItemSaveSample\` 10-item save loop in \`test_uom_migration\`

## Approach

**Raise \`timeout-minutes: 8 → 20\`.** Considered and rejected the other options:

| Option | Verdict |
|---|---|
| **pytest-xdist \`-n auto\`** | ❌ [conftest.py:40](tests/ui/conftest.py#L40) scopes \`acumatica_page\` to \`session\`. N workers = N concurrent Acumatica logins → API Login Limit hits. Tests also mutate shared state (order cleanup in \`autouse\` fixture) — races likely. |
| **Split into multiple steps** | ❌ Each new step reruns \`pip install playwright pytest pytest-timeout\` + \`playwright install chromium\` + a fresh Acumatica login. 1–2 min overhead × 3 steps easily costs more than it saves, and multiplies login count. |
| **Trim \`test_screen_smoke\` screens** | ❌ The screen list is [audit-derived](scripts/heritage/generate_ui_fixtures.py) from screens that actually wrote \`Usr*\` fields in production. Dropping any weakens regression coverage — that's the whole point of the gate. |
| **Raise timeout** | ✅ Safe. Tests are genuinely this slow (sandbox page loads ~30 s each). Matches the [PR #362](https://github.com/studio-b-ai/acumatica-ci-cd/pull/362) pattern (container-tracking step bumped 20 → 35 when its suite grew). Per-test \`--timeout=120\` still catches genuinely hung tests. |

**Why 20 min specifically:** 11 min suite × ~80% headroom = 20 min. Matches the value PR #362 used for the container-tracking step before its own growth-driven bump. Still well under the job-level \`timeout-minutes: 40\`.

## Gate is preserved

Nothing is skipped or deferred. The step still runs the full test set with the full pytest invocation. What changes is only the wall-clock cap — which was failing the gate not because tests were broken but because 32% of them never got to run.

## Verification

- Local actionlint on the edit site: clean (the 8 pre-existing shellcheck warnings are on lines 215/393/748/841, not in my diff).
- Workflow signal on the gate itself only fires via \`workflow_dispatch\` of AcuOps Build — can be kicked after merge (brief calls this out as not-urgent, so running a full sandbox publish just to prove the timeout isn't warranted).
- Evidence from run 24569665633 is already the strongest possible verification: the tests that ran **passed** — they just ran out of clock.

## Follow-ups

- **Close #452.** With the real timeout fix in, the \`SAVE_SAMPLE_SIZE\` 10 → 5 reduction is no longer needed; the full sample gives better corruption-detection confidence.
- **Separate P1.1 bug (out of scope here):** the \`Generate UI fixtures from audit data\` step has \`continue-on-error: true\` because \`generate_ui_fixtures.py\` 404s on an OData endpoint. Tracked in \`docs/prompts/2026-04-08-execute-phase3-convergence.md\`. When it runs, the fixture list refreshes from live audit data; when it doesn't, \`test_screen_smoke\` falls back to whatever was committed. Not fixed here.

## Test plan

- [ ] Merge this PR
- [ ] Trigger \`AcuOps Build\` via \`workflow_dispatch\` (or let the next prod deploy trigger it)
- [ ] Confirm \`Run core UI tests\` completes cleanly within 20 min
- [ ] Close #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)