### PR TITLE
fix(ui-tests): PO301000 container-tracking tests — iframe-scoped locator

### DIFF
--- a/tests/ui/test_container_tracking.py
+++ b/tests/ui/test_container_tracking.py
@@ -143,19 +143,31 @@ class TestPO301000ContainerFields:
         screen.assert_no_errors()
 
     def test_container_tracking_button_exists(self, acumatica_screen):
-        """CONTAINER TRACKING toolbar button should be present on PO301000."""
+        """CONTAINER TRACKING toolbar button should be present on PO301000.
+
+        NOTE: Acumatica renders all screen content (including the toolbar)
+        inside iframe[name='main']. Use `screen.locator(...)` which is
+        scoped to the iframe context — NOT `screen.page.locator(...)`
+        which only sees the top-level frame and will return 0 even when
+        the button is rendered. CLAUDE.md rule #20 (2026-04-15 incident).
+        """
         screen = acumatica_screen("PO301000")
         screen.page.wait_for_timeout(3_000)
 
-        btn = screen.page.locator("text=CONTAINER TRACKING")
+        btn = screen.locator("text=CONTAINER TRACKING")
         assert btn.count() > 0, "CONTAINER TRACKING button not found on PO301000"
 
     def test_container_tracking_navigates_to_sb501000(self, acumatica_screen):
-        """Clicking CONTAINER TRACKING should navigate to SB501000 without error."""
+        """Clicking CONTAINER TRACKING should navigate to SB501000 without error.
+
+        Same iframe-descent note as test_container_tracking_button_exists —
+        locate the button via `screen.locator()` (iframe-scoped), not
+        `screen.page.locator()`.
+        """
         screen = acumatica_screen("PO301000")
         screen.page.wait_for_timeout(3_000)
 
-        btn = screen.page.locator("text=CONTAINER TRACKING").first
+        btn = screen.locator("text=CONTAINER TRACKING").first
         if btn.is_visible(timeout=3000):
             btn.click()
             screen.page.wait_for_load_state("domcontentloaded")


### PR DESCRIPTION
## Summary

Two tests in `tests/ui/test_container_tracking.py` used the raw top-frame locator (`screen.page.locator(...)`) instead of the iframe-scoped one (`screen.locator(...)`). Acumatica renders the PO301000 toolbar inside `iframe[name='main']`, so the raw locator returned `count() == 0` and the tests failed even though the `CONTAINER TRACKING` button is visibly present.

This is the [CLAUDE.md rule #20](https://github.com/studio-b-ai/acumatica-ci-cd/blob/main/CLAUDE.md) pattern from the 2026-04-15 PCC incident — a test-locator bug that looks exactly like a customization bug. Same fix shape: switch to the iframe-aware context helper the rest of the suite already uses.

## Evidence

Verified on sandbox `heritagefabrics-sandbox.acumatica.com` at 2026-04-17T20:36Z via live Playwright navigation:

| Locator | `count()` |
|---|---|
| `page.locator("text=CONTAINER TRACKING")` (old — top frame) | 0 |
| `screen.locator("text=CONTAINER TRACKING")` (new — iframe ctx) | 3 (1 nav + 2 toolbar) |

Screenshot in session output (`sandbox-po301000-has-container-tracking.png`) shows the `CONTAINER TRACKING` button rendered right next to `REMOVE HOLD` in the PO301000 toolbar.

## Root cause

`AcumaticaScreen.navigate()` (tests/ui/acumatica_screen.py) resolves `iframe[name='main']` into `self.ctx` and exposes it as `screen.locator()`. The two failing tests reached around that helper and hit the raw `Page`, which only sees the top frame.

## Blast radius of the false-negative

This locator false-negative blocked PR [#454](https://github.com/studio-b-ai/acumatica-ci-cd/pull/454)'s sandbox gate at 2026-04-17T20:25Z during the post-merge `acuops-build` run (run [24584184638](https://github.com/studio-b-ai/acumatica-ci-cd/actions/runs/24584184638)). PR #454 ships the DRP-GI-orphan cleanup plugin (merged commit 4e800aa) that resolves the 14-hour Heritage Fabrics prod `UserRecordsDBUpdater` NRE. The prod deploy proceeded via `skip_sandbox_gate=OVERRIDE` with this test-fix finding as the documented justification (run [24585730350](https://github.com/studio-b-ai/acumatica-ci-cd/actions/runs/24585730350)).

## Test plan

- [ ] Sandbox run of `@acumatica` smoke suite shows `test_container_tracking_button_exists` + `test_container_tracking_navigates_to_sb501000` PASS
- [ ] Full sandbox UI suite passes (all 63+ tests)
- [ ] Auto-qualifier runs clean on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)