### PR TITLE
ci: grant contents:write to deploy job so Tag step stops 403'ing

### DIFF
--- a/.github/workflows/acuops-deploy.yml
+++ b/.github/workflows/acuops-deploy.yml
@@ -409,6 +409,16 @@ jobs:
     name: Deploy to ${{ inputs.environment }}
     needs: [sandbox-gate]
     runs-on: ubuntu-latest
+    # contents: write — required by the final "Tag successful deploy" step,
+    # which pushes a deploy/prod/YYYYMMDD-HHMMSS tag back to the repo. The
+    # workflow-level permissions grant only contents: read, so without this
+    # override every successful prod deploy fails with HTTP 403 at the tag
+    # push and is reported as an overall job failure even though the
+    # Acumatica publish succeeded. Observed 2026-04-17 on run 24585730350.
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     if: >
       always() &&
       inputs.customization_changes == 'true' &&


### PR DESCRIPTION
## Summary

The `deploy` job in `.github/workflows/acuops-deploy.yml` ends with a `Tag successful deploy` step that pushes `deploy/prod/YYYYMMDD-HHMMSS` back to the repo. The workflow-level `permissions:` block grants only `contents: read`, so `git push origin "${TAG}"` 403's every time and the overall job is marked failure — even when the Acumatica publish succeeded cleanly.

This PR adds a job-level `permissions` override that grants `contents: write` to the `deploy` job alone. Other jobs (build, qualify, sandbox-gate, AI Failure Recovery) keep the existing `contents: read`.

## Incident that surfaced it

Run [24585730350](https://github.com/studio-b-ai/acumatica-ci-cd/actions/runs/24585730350) — manual dispatch of the DRP-GI-orphan cleanup plugin to prod. Everything worked:

```
Verify | success
Alert  | skipped
[AesthetikContainers] DRP GI orphan scan CID=1 — clean (0 stale)
[AesthetikContainers] DRP GI orphan scan CID=2 — clean (0 stale)
[AesthetikContainers] DRP GI orphan scan CID=3 — clean (0 stale)
[AesthetikContainers] DRP GI orphan scan CID=4 — clean (0 stale)
```

Then:

```
remote: Permission to studio-b-ai/acumatica-ci-cd.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/studio-b-ai/acumatica-ci-cd/': The requested URL returned error: 403
##[error]Process completed with exit code 128.
```

The job exited 128 and downstream steps (success notification, Slack, etc.) were all skipped even though the customization shipped clean. Reading the tea leaves of the failing log lines to confirm the publish *did* succeed is not an acceptable post-deploy signal.

## Why a job-level override (vs. bumping the workflow-level block)

GitHub resolves job-level `permissions:` as a full replacement of the workflow-level block, not a merge. Narrowing to the single job that needs it keeps `contents: write` out of the surface of the other jobs (build runs third-party checkout, qualify runs arbitrary AI actions, sandbox-gate runs Playwright against a live instance). Least-privilege for everything else.

The job-level block also carries forward `id-token: write` + `pull-requests: write` from the workflow-level so nothing else changes behaviour.

## Test plan

- [ ] Next prod deploy run completes without the `Tag successful deploy` step 403'ing
- [ ] Tag `deploy/prod/<ts>` appears on the repo's tags list
- [ ] Slack notification posts on success (was being skipped because the job was marked failed)
- [ ] actionlint / auto-qualifier pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)