### PR TITLE
fix(drp): bump DesignIDs + SiteMap NodeIDs for 5 DRP Phase 0 GIs

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -2139,7 +2139,7 @@ public partial class Page_SB_SB302040 : PXPage
 </layout>
     <data>
       <GIDesign>
-        <row DesignID="1ce25f0a-cde6-4f0a-b939-d274fe343574" Name="DRP_VelocityHistory" ScreenID="SB401080" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+        <row DesignID="52ebcf52-7256-47d9-9256-974a33660702" Name="DRP_VelocityHistory" ScreenID="SB401080" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
           <GITable Alias="SOShipLine" Name="PX.Objects.SO.SOShipLine">
             <GIRelation LineNbr="1" ChildTable="SOShipment" IsActive="1" JoinType="L">
               <GIOn LineNbr="1" ParentField="ShipmentNbr" Condition="E " ChildField="ShipmentNbr" Operation="A" />
@@ -2166,7 +2166,7 @@ public partial class Page_SB_SB302040 : PXPage
           <GIWhere LineNbr="2" IsActive="1" DataFieldName="SOShipment.Operation" Condition="E " IsExpression="0" Value1="I" Operation="A" />
           <GISort LineNbr="1" IsActive="1" DataFieldName="SOShipment.ShipDate" SortOrder="D" />
           <SiteMap linkname="toDesignById">
-            <row Position="1160" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=1ce25f0a-cde6-4f0a-b939-d274fe343574" Expanded="0" IsFolder="0" ScreenID="SB401080" NodeID="aed2bb14-04d3-4715-ba57-6bd405423270" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
+            <row Position="1160" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=52ebcf52-7256-47d9-9256-974a33660702" Expanded="0" IsFolder="0" ScreenID="SB401080" NodeID="8361e7f4-c50a-48fc-ad2a-8527796efa89" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2070" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
               <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
               <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
@@ -2312,7 +2312,7 @@ public partial class Page_SB_SB302040 : PXPage
 </layout>
     <data>
       <GIDesign>
-        <row DesignID="f918a504-7620-461c-aad8-f1b3395d1e79" Name="DRP_OpenSOCommitments" ScreenID="SB401090" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+        <row DesignID="8771befb-f3d9-4c14-8898-e9b1f249addc" Name="DRP_OpenSOCommitments" ScreenID="SB401090" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
           <GITable Alias="SOOrder" Name="PX.Objects.SO.SOOrder">
             <GIRelation LineNbr="1" ChildTable="SOLine" IsActive="1" JoinType="I">
               <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
@@ -2339,7 +2339,7 @@ public partial class Page_SB_SB302040 : PXPage
           <GIWhere LineNbr="5" CloseBrackets="1" IsActive="1" DataFieldName="SOLine.OrderType" Condition="E " IsExpression="0" Value1="PC" Operation="A" />
           <GISort LineNbr="1" IsActive="1" DataFieldName="SOLine.RequestDate" SortOrder="A" />
           <SiteMap linkname="toDesignById">
-            <row Position="1170" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=f918a504-7620-461c-aad8-f1b3395d1e79" Expanded="0" IsFolder="0" ScreenID="SB401090" NodeID="af758f49-f888-4d32-b162-838a5fa34c52" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
+            <row Position="1170" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=8771befb-f3d9-4c14-8898-e9b1f249addc" Expanded="0" IsFolder="0" ScreenID="SB401090" NodeID="cd1df10e-11fb-4d1a-b433-16547128bb75" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2080" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
               <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
               <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
@@ -2485,7 +2485,7 @@ public partial class Page_SB_SB302040 : PXPage
 </layout>
     <data>
       <GIDesign>
-        <row DesignID="a5337a02-6d79-42e9-b400-d7178ac3fd24" Name="DRP_InventoryBySite" ScreenID="SB401110" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+        <row DesignID="b6cadfdd-f802-4456-8a7a-9f52dc271145" Name="DRP_InventoryBySite" ScreenID="SB401110" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
           <GITable Alias="InventoryItem" Name="PX.Objects.IN.InventoryItem">
             <GIRelation LineNbr="1" ChildTable="INSiteStatus" IsActive="1" JoinType="I">
               <GIOn LineNbr="1" ParentField="InventoryID" Condition="E " ChildField="InventoryID" Operation="A" />
@@ -2508,7 +2508,7 @@ public partial class Page_SB_SB302040 : PXPage
           <GISort LineNbr="1" IsActive="1" DataFieldName="InventoryItem.InventoryCD" SortOrder="A" />
           <GISort LineNbr="2" IsActive="1" DataFieldName="INSiteStatus.SiteID" SortOrder="A" />
           <SiteMap linkname="toDesignById">
-            <row Position="1180" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=a5337a02-6d79-42e9-b400-d7178ac3fd24" Expanded="0" IsFolder="0" ScreenID="SB401110" NodeID="1fb65d0f-ebc6-4ec5-8e19-5c5022245ff5" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
+            <row Position="1180" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=b6cadfdd-f802-4456-8a7a-9f52dc271145" Expanded="0" IsFolder="0" ScreenID="SB401110" NodeID="682ab364-373a-4102-ad65-2f97fdd4b95d" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2090" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
               <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
               <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
@@ -2654,7 +2654,7 @@ public partial class Page_SB_SB302040 : PXPage
 </layout>
     <data>
       <GIDesign>
-        <row DesignID="89912975-c6ed-41ad-b514-a0f775a89362" Name="DRP_OpenPOLines" ScreenID="SB401100" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+        <row DesignID="263148fc-5b6a-4312-8c45-6e590415ea3a" Name="DRP_OpenPOLines" ScreenID="SB401100" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
           <GITable Alias="POOrder" Name="PX.Objects.PO.POOrder">
             <GIRelation LineNbr="1" ChildTable="Line" IsActive="1" JoinType="I">
               <GIOn LineNbr="1" ParentField="OrderType" Condition="E " ChildField="OrderType" Operation="A" />
@@ -2693,7 +2693,7 @@ public partial class Page_SB_SB302040 : PXPage
           <GIWhere LineNbr="4" CloseBrackets="1" IsActive="1" DataFieldName="POOrder.Status" Condition="E " IsExpression="0" Value1="O" Operation="A" />
           <GISort LineNbr="1" IsActive="1" DataFieldName="Line.PromisedDate" SortOrder="A" />
           <SiteMap linkname="toDesignById">
-            <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="660b0c64-b2bf-4848-a863-468f5ff34fbd" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
+            <row Position="1190" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=263148fc-5b6a-4312-8c45-6e590415ea3a" Expanded="0" IsFolder="0" ScreenID="SB401100" NodeID="ff293138-f357-4b52-a934-62d3f1fb82d0" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
               <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
               <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
@@ -2701,7 +2701,7 @@ public partial class Page_SB_SB302040 : PXPage
           </SiteMap>
 
         </row>
-        <row DesignID="6e77b05f-ef4d-49e7-90ac-4c703006880d" Name="DRP_ItemWarehouseSettings" ScreenID="SB401120" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
+        <row DesignID="969bfd48-5eaa-470a-b806-4bb46cf494d6" Name="DRP_ItemWarehouseSettings" ScreenID="SB401120" FilterColCount="3" PageSize="0" ExportTop="0" NewRecordCreationEnabled="0" MassDeleteEnabled="0" AutoConfirmDelete="0" MassRecordsUpdateEnabled="0" MassActionsOnRecordsEnabled="0" ExposeViaOData="1" ExposeViaMobile="0">
           <GITable Alias="INItemSite" Name="PX.Objects.IN.INItemSite">
             <GIRelation LineNbr="1" ChildTable="InventoryItem" IsActive="1" JoinType="L">
               <GIOn LineNbr="1" ParentField="InventoryID" Condition="E " ChildField="InventoryID" Operation="A" />
@@ -2739,7 +2739,7 @@ public partial class Page_SB_SB302040 : PXPage
           <GISort LineNbr="1" IsActive="1" DataFieldName="InventoryItem.InventoryCD" SortOrder="A" />
           <GISort LineNbr="2" IsActive="1" DataFieldName="INSite.SiteCD" SortOrder="A" />
           <SiteMap linkname="toDesignById">
-            <row Position="1190" Title="DRP Item Warehouse Settings" Url="~/GenericInquiry/GenericInquiry.aspx?id=6e77b05f-ef4d-49e7-90ac-4c703006880d" Expanded="0" IsFolder="0" ScreenID="SB401120" NodeID="3e124ece-6462-4be9-acc7-6372d6da32ef" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
+            <row Position="1190" Title="DRP Item Warehouse Settings" Url="~/GenericInquiry/GenericInquiry.aspx?id=969bfd48-5eaa-470a-b806-4bb46cf494d6" Expanded="0" IsFolder="0" ScreenID="SB401120" NodeID="aa4ce5d7-78e1-46bb-b08a-67bf65f70504" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87">
               <MUIScreen IsPortal="0" WorkspaceID="95191203-a0b8-4fc0-8b20-4efe831708e9" Order="2100" SubcategoryID="acf1bb34-2055-411e-88be-d840efcc7424" />
               <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
               <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
@@ -2827,19 +2827,19 @@ public partial class Page_SB_SB302040 : PXPage
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>
-                    <row Position="0" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=1ce25f0a-cde6-4f0a-b939-d274fe343574" ScreenID="SB401080" NodeID="1ce25f0a-cde6-4f0a-b939-d274fe343574" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
+                    <row Position="0" Title="DRP Velocity History" Url="~/GenericInquiry/GenericInquiry.aspx?id=52ebcf52-7256-47d9-9256-974a33660702" ScreenID="SB401080" NodeID="52ebcf52-7256-47d9-9256-974a33660702" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>
-                    <row Position="0" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=f918a504-7620-461c-aad8-f1b3395d1e79" ScreenID="SB401090" NodeID="f918a504-7620-461c-aad8-f1b3395d1e79" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
+                    <row Position="0" Title="DRP Open SO Commitments" Url="~/GenericInquiry/GenericInquiry.aspx?id=8771befb-f3d9-4c14-8898-e9b1f249addc" ScreenID="SB401090" NodeID="8771befb-f3d9-4c14-8898-e9b1f249addc" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>
-                    <row Position="0" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=89912975-c6ed-41ad-b514-a0f775a89362" ScreenID="SB401100" NodeID="89912975-c6ed-41ad-b514-a0f775a89362" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
+                    <row Position="0" Title="DRP Open PO Lines" Url="~/GenericInquiry/GenericInquiry.aspx?id=263148fc-5b6a-4312-8c45-6e590415ea3a" ScreenID="SB401100" NodeID="263148fc-5b6a-4312-8c45-6e590415ea3a" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>
-                    <row Position="0" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=a5337a02-6d79-42e9-b400-d7178ac3fd24" ScreenID="SB401110" NodeID="a5337a02-6d79-42e9-b400-d7178ac3fd24" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
+                    <row Position="0" Title="DRP Inventory By Site" Url="~/GenericInquiry/GenericInquiry.aspx?id=b6cadfdd-f802-4456-8a7a-9f52dc271145" ScreenID="SB401110" NodeID="b6cadfdd-f802-4456-8a7a-9f52dc271145" ParentID="9c89e3db-7c47-43c0-8554-5d2c9f2c0e87" SelectedUI="E">
                         <RolesInGraph Rolename="Administrator" ApplicationName="/" Accessrights="4" />
                         <RolesInGraph Rolename="*" ApplicationName="/" Accessrights="4" />
                     </row>

--- a/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
+++ b/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
@@ -1004,11 +1004,11 @@ namespace StudioB.Containers
         private static readonly System.Collections.Generic.Dictionary<string, Guid> DRPCanonDesigns =
             new System.Collections.Generic.Dictionary<string, Guid>(StringComparer.Ordinal)
         {
-            { "DRP_VelocityHistory",       new Guid("1ce25f0a-cde6-4f0a-b939-d274fe343574") },
-            { "DRP_OpenSOCommitments",     new Guid("f918a504-7620-461c-aad8-f1b3395d1e79") },
-            { "DRP_InventoryBySite",       new Guid("a5337a02-6d79-42e9-b400-d7178ac3fd24") },
-            { "DRP_OpenPOLines",           new Guid("89912975-c6ed-41ad-b514-a0f775a89362") },
-            { "DRP_ItemWarehouseSettings", new Guid("6e77b05f-ef4d-49e7-90ac-4c703006880d") },
+            { "DRP_VelocityHistory",       new Guid("52ebcf52-7256-47d9-9256-974a33660702") },
+            { "DRP_OpenSOCommitments",     new Guid("8771befb-f3d9-4c14-8898-e9b1f249addc") },
+            { "DRP_InventoryBySite",       new Guid("b6cadfdd-f802-4456-8a7a-9f52dc271145") },
+            { "DRP_OpenPOLines",           new Guid("263148fc-5b6a-4312-8c45-6e590415ea3a") },
+            { "DRP_ItemWarehouseSettings", new Guid("969bfd48-5eaa-470a-b806-4bb46cf494d6") },
         };
 
         private void CleanupOrphanDRPGIRows(SqlConnection conn, int companyId)


### PR DESCRIPTION
## Summary

Install the 4 missing DRP Phase 0 Generic Inquiries on Heritage Fabrics prod AND fix the 403 on `DRP_ItemWarehouseSettings` by giving all 5 GIs fresh DesignIDs + inline SiteMap NodeIDs.

## Step 1 — Phase 1 Investigation Findings (2026-04-17 21:20Z)

**OData state on prod (api-bot basic auth):**

| GI | ScreenID | OData |
|---|---|:---:|
| DRP_VelocityHistory | SB401080 | 404 |
| DRP_OpenSOCommitments | SB401090 | 404 |
| DRP_InventoryBySite | SB401110 | 404 |
| DRP_OpenPOLines | SB401100 | 404 |
| DRP_ItemWarehouseSettings | SB401120 | 403 |

**Published package inspection** (via `POST /CustomizationApi/getProject` → base64-decode → zipfile → `project.xml`):

1. All 5 DRP `<GenericInquiryScreen>` blocks ARE in the published prod package with correct canonical DesignIDs.
2. All 5 blocks have `<RolesInGraph Rolename="*" Accessrights="4"/>` inline inside their `<SiteMap>/<row>` — CLAUDE.md rule #17 is satisfied in XML.
3. **Structural observation:** `DRP_OpenPOLines` and `DRP_ItemWarehouseSettings` are siblings inside a single `<GenericInquiryScreen>` wrapper (lines 2523-2753). The other 3 each have their own wrapper. Did not change this structure — it's what PR #445's export produced and other packages seem to survive it.
4. The integration-level `ScreenWithRights` block lists SB401080-SB401110 but not SB401120. Per rule #17 that block doesn't govern OData access, so I did NOT change it.

**Broader state beyond scope (flagged for follow-up):**

Only 2/12 AesthetikContainers GIs are on OData. The other 10 are also missing:

| GI (ScreenID) | OData | |---|:---:|
| LandedCostSummary (SB401070) | **200** ✓ |
| DRP_ItemWarehouseSettings (SB401120) | 403 |
| All 10 others (incl. 4 DRP + 6 container-tracking) | 404 |

Sandbox has 0/12 AesthetikContainers GIs registered — so the sandbox gate will exercise a clean fresh-install path for these 5, not a merge/tracking path.

**Interpretation:** The theory in the task brief holds — Acumatica's publish engine silently skipped data-set application for most `<GenericInquiryScreen>` blocks in this package across PRs #427/#430/#431/#445/#454. A fresh DesignID forces Acumatica to treat the block as never-seen, triggering a clean INSERT of `GIDesign` + children + `SiteMap` row + inline `<RolesInGraph>` children.

**Why I bumped DRP_ItemWarehouseSettings too (despite the task's "unless required" guidance):**
- The 403 is caused by SiteMap row existing without inline `<RolesInGraph>` children being applied.
- No observable way to make the publish engine re-apply inline children without a fresh INSERT.
- Splitting into two deploys doubles the app-pool-restart disruption (rule #11).
- The orphan cleanup plugin (`CleanupOrphanDRPGIRows`, unchanged) cleans the old `6e77b05f-...` row automatically on this same publish.
- The XML for `DRP_ItemWarehouseSettings` is identical in structure to the other 4 — bumping it is the same operation, not a special case.

## DesignID + NodeID Mapping

| GI | Old DesignID | New DesignID | Old SiteMap NodeID | New SiteMap NodeID |
|---|---|---|---|---|
| `DRP_VelocityHistory` | `1ce25f0a-cde6-4f0a-b939-d274fe343574` | `52ebcf52-7256-47d9-9256-974a33660702` | `aed2bb14-04d3-4715-ba57-6bd405423270` | `8361e7f4-c50a-48fc-ad2a-8527796efa89` |
| `DRP_OpenSOCommitments` | `f918a504-7620-461c-aad8-f1b3395d1e79` | `8771befb-f3d9-4c14-8898-e9b1f249addc` | `af758f49-f888-4d32-b162-838a5fa34c52` | `cd1df10e-11fb-4d1a-b433-16547128bb75` |
| `DRP_InventoryBySite` | `a5337a02-6d79-42e9-b400-d7178ac3fd24` | `b6cadfdd-f802-4456-8a7a-9f52dc271145` | `1fb65d0f-ebc6-4ec5-8e19-5c5022245ff5` | `682ab364-373a-4102-ad65-2f97fdd4b95d` |
| `DRP_OpenPOLines` | `89912975-c6ed-41ad-b514-a0f775a89362` | `263148fc-5b6a-4312-8c45-6e590415ea3a` | `660b0c64-b2bf-4848-a863-468f5ff34fbd` | `ff293138-f357-4b52-a934-62d3f1fb82d0` |
| `DRP_ItemWarehouseSettings` | `6e77b05f-ef4d-49e7-90ac-4c703006880d` | `969bfd48-5eaa-470a-b806-4bb46cf494d6` | `3e124ece-6462-4be9-acc7-6372d6da32ef` | `aa4ce5d7-78e1-46bb-b08a-67bf65f70504` |

## Changes

- `Customization/AesthetikContainers/project.xml` — 14 line edits substituting 5 DesignIDs + 5 NodeIDs across GIDesign rows, inline SiteMap URLs/NodeIDs, and workspace tile NodeID/URL references (lines 2142, 2169, 2315, 2342, 2488, 2511, 2657, 2696, 2704, 2742, 2830, 2834, 2838, 2842).
- `src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs` — `DRPCanonDesigns` dictionary updated to match (5 line edits). `CleanupOrphanDRPGIRows` method body UNCHANGED (explicit task constraint).

## What's Explicitly Not Changed

- `CleanupOrphanDRPGIRows` method body — task constraint
- `ScreenWithRights` integration block — rule #17 says it doesn't govern OData access
- `scripts/build_drp_*.py` build-time splicers — they're idempotent one-shots frozen at their historical DesignIDs; not invoked by the pipeline
- Any of the 6 non-DRP AesthetikContainers GIs with the same 404 symptom — flagged for follow-up, out of scope for this PR

## Downstream Search

`grep -rln '<5 old DesignID GUIDs>'` across `/Users/kevin/dev/` found matches only in `acumatica-ci-cd/Customization/AesthetikContainers/project.xml`, `acumatica-ci-cd/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs`, and the 3 historical `scripts/build_drp_*.py` splicers. No hardcoded DesignIDs in `webhook-router` or `acudev`. No downstream callers to coordinate.

## Local Sanity Checks

- `ElementTree.parse('project.xml')` — OK
- `python3 scripts/sync-aspx-cdata.py --check` — all in sync (14 ASPX entries)
- Zero occurrences of any old DesignID remain in `Customization/AesthetikContainers/project.xml` or `src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs`

## Test Plan

- [ ] Sandbox gate tests pass (no `skip_sandbox_gate` override)
- [ ] Kevin merges during an after-hours window (rule #11 — every publish restarts the app pool)
- [ ] Post-deploy OData probe shows all 5 GIs returning HTTP 200:
  ```bash
  for GI in DRP_VelocityHistory DRP_OpenSOCommitments DRP_InventoryBySite DRP_OpenPOLines DRP_ItemWarehouseSettings; do
    curl -sS -u "api-bot:\$ACU_PASS" \
      "https://heritagefabrics.acumatica.com/OData/Heritage%20Fabrics/\$GI?\$top=1" \
      -w "\n\$GI: %{http_code}\n"
  done
  ```
- [ ] Step 4 verification output pasted back into this PR after deploy
- [ ] Follow-up: open separate ticket for the 6 other AesthetikContainers GIs with the same 404 symptom

🤖 Generated with [Claude Code](https://claude.com/claude-code)