### PR TITLE
audit(wms): annotate 26 reviewed instance GetExtension<>() sites

### DIFF
--- a/src/StudioB.Containers/Graphs/POOrderEntry_Extension.cs
+++ b/src/StudioB.Containers/Graphs/POOrderEntry_Extension.cs
@@ -41,6 +41,7 @@ namespace StudioB.Containers
             POOrder order = Base.Document.Current;
             if (order == null) return;
 
+            // REVIEWED: extension-safe — Base.Document.Current, cache-init
             POOrderExt ext = order.GetExtension<POOrderExt>();
             string containerRef = ext?.UsrContainerRef;
 
@@ -82,6 +83,7 @@ namespace StudioB.Containers
             POOrder header = Base.Document.Current;
             if (header != null)
             {
+                // REVIEWED: extension-safe — Base.Document.Current, cache-init
                 POOrderExt headerExt = header.GetExtension<POOrderExt>();
                 if (headerExt?.UsrExpArrivalDate != null)
                 {
@@ -166,6 +168,7 @@ namespace StudioB.Containers
                 foreach (POLine line in Base.Transactions.Select())
                 {
                     if (line == null) continue;
+                    // REVIEWED: extension-safe — row from Base.Transactions.Select(), cache-init
                     POLineExt lineExt = line.GetExtension<POLineExt>();
                     if (lineExt == null) continue;
 

--- a/src/StudioB.WMS/Graphs/CrossDockManager.cs
+++ b/src/StudioB.WMS/Graphs/CrossDockManager.cs
@@ -37,6 +37,7 @@ namespace Aesthetik.WMS
         private CrossDockConfig GetConfig()
         {
             var setup = SelectFrom<INSetup>.View.ReadOnly.SelectSingleBound(Base, null);
+            // REVIEWED: extension-safe — INSetup singleton via SelectSingleBound, cache-init
             var ext = ((INSetup)setup)?.GetExtension<INSetupExt>();
 
             return new CrossDockConfig
@@ -70,6 +71,7 @@ namespace Aesthetik.WMS
             foreach (PXResult<INLotSerialStatus> row in allSerials)
             {
                 var status = (INLotSerialStatus)row;
+                // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
                 var ext = status.GetExtension<INLotSerialStatusExt>();
                 if (!string.IsNullOrEmpty(ext?.UsrContainerNo))
                 {
@@ -159,6 +161,7 @@ namespace Aesthetik.WMS
                 throw new PXException($"Serial '{serialNbr}' not found for inventory ID {inventoryID}.");
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             // Validate current status
@@ -193,6 +196,7 @@ namespace Aesthetik.WMS
                 throw new PXException($"Serial '{serialNbr}' not found.");
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             if (ext.UsrInventoryStatus != PieceGoodsConstants.InvStatus_Receiving)
@@ -246,6 +250,7 @@ namespace Aesthetik.WMS
             if (statusRow == null) return; // May already be consumed by shipment
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             // Only transition from Receiving status (cross-dock path)
@@ -288,6 +293,7 @@ namespace Aesthetik.WMS
             foreach (PXResult<INLotSerialStatus> row in receivingRolls)
             {
                 var status = (INLotSerialStatus)row;
+                // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
                 var ext = status.GetExtension<INLotSerialStatusExt>();
 
                 if (ext?.UsrInventoryStatus != PieceGoodsConstants.InvStatus_Receiving)

--- a/src/StudioB.WMS/Graphs/PieceGoodsReceivingExt.cs
+++ b/src/StudioB.WMS/Graphs/PieceGoodsReceivingExt.cs
@@ -73,6 +73,7 @@ namespace Aesthetik.WMS
             POReceiptLine receiptLine,
             GS1128Result parsed)
         {
+            // REVIEWED: extension-safe — preReceived returned by FindPreReceivedSerial() which loads via SelectFrom<>.View.Select(Base), cache-init
             var ext = preReceived.GetExtension<INLotSerialStatusExt>();
             var config = GetReceivingConfig();
 
@@ -134,6 +135,7 @@ namespace Aesthetik.WMS
                 return new YardageConfirmResult { Success = false, ErrorMessage = "Serial not found." };
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
             var config = GetReceivingConfig();
 
@@ -216,6 +218,7 @@ namespace Aesthetik.WMS
 
             status = (INLotSerialStatus)statusCache.Insert(status);
 
+            // REVIEWED: extension-safe — status returned by statusCache.Insert() is explicitly cache-bound
             var ext = status.GetExtension<INLotSerialStatusExt>();
             ext.UsrActualYardage = yardage;
             ext.UsrDyeLot = dyeLot;
@@ -334,6 +337,7 @@ namespace Aesthetik.WMS
             if (result == null) return null;
 
             var status = (INLotSerialStatus)result;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.ReadOnly.Select(Base), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             // Only match if status is In-Transit (pre-received but not physically received)
@@ -392,6 +396,7 @@ namespace Aesthetik.WMS
         private ReceivingConfig GetReceivingConfig()
         {
             var setup = SelectFrom<INSetup>.View.ReadOnly.SelectSingleBound(Base, null);
+            // REVIEWED: extension-safe — INSetup singleton via SelectSingleBound, cache-init
             var ext = ((INSetup)setup)?.GetExtension<INSetupExt>();
 
             return new ReceivingConfig

--- a/src/StudioB.WMS/Graphs/SOOrderEntry_AutoAllocation.cs
+++ b/src/StudioB.WMS/Graphs/SOOrderEntry_AutoAllocation.cs
@@ -160,6 +160,7 @@ namespace HeritageFabrics.SO
 
                 // Use UsrRequestedQty if already set (re-save scenario),
                 // otherwise use current OrderQty (first allocation)
+                // REVIEWED: extension-safe — line from Base.Transactions.Select(), cache-init
                 var lineExt = line.GetExtension<SOLineExt>();
                 decimal requestedQty;
 

--- a/src/StudioB.WMS/Graphs/TextilePickOptimizer.cs
+++ b/src/StudioB.WMS/Graphs/TextilePickOptimizer.cs
@@ -199,6 +199,7 @@ namespace Aesthetik.WMS
             foreach (PXResult<INLotSerialStatus> row in allSerials)
             {
                 var status = (INLotSerialStatus)row;
+                // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(Base), cache-init
                 var ext = status.GetExtension<INLotSerialStatusExt>();
 
                 if (ext == null) continue;
@@ -324,6 +325,7 @@ namespace Aesthetik.WMS
         private OptimizerWeights LoadWeights()
         {
             var setup = SelectFrom<INSetup>.View.ReadOnly.SelectSingleBound(Base, null);
+            // REVIEWED: extension-safe — INSetup singleton via SelectSingleBound, cache-init
             var ext = ((INSetup)setup)?.GetExtension<INSetupExt>();
             return OptimizerWeights.FromSetup(ext);
         }

--- a/src/StudioB.WMS/Logic/CutToOrderEngine.cs
+++ b/src/StudioB.WMS/Logic/CutToOrderEngine.cs
@@ -37,6 +37,7 @@ namespace Aesthetik.WMS
         private CutConfig GetConfig()
         {
             var setup = SelectFrom<INSetup>.View.ReadOnly.SelectSingleBound(_graph, null);
+            // REVIEWED: extension-safe — INSetup singleton via SelectSingleBound, cache-init
             var setupExt = ((INSetup)setup)?.GetExtension<INSetupExt>();
 
             return new CutConfig
@@ -95,6 +96,7 @@ namespace Aesthetik.WMS
                 return new CutResult { Success = false, ErrorMessage = "Source serial not found." };
 
             var source = (INLotSerialStatus)sourceStatus;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(_graph), cache-init
             var sourceExt = source.GetExtension<INLotSerialStatusExt>();
 
             // ── STEP 3: Generate cut piece serial number ───────────────
@@ -215,6 +217,7 @@ namespace Aesthetik.WMS
                 return new CutValidation { IsValid = false, ErrorMessage = "Source serial not found." };
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.ReadOnly.Select(_graph), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             // Check lot/serial class
@@ -322,6 +325,7 @@ namespace Aesthetik.WMS
             if (statusRow == null) return;
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(_graph), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             ext.UsrActualYardage = remainingYardage;
@@ -347,6 +351,7 @@ namespace Aesthetik.WMS
             if (statusRow == null) return;
 
             var status = (INLotSerialStatus)statusRow;
+            // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(_graph), cache-init
             var ext = status.GetExtension<INLotSerialStatusExt>();
 
             // Set cut piece yardage

--- a/src/StudioB.WMS/Logic/PreReceivingEngine.cs
+++ b/src/StudioB.WMS/Logic/PreReceivingEngine.cs
@@ -415,6 +415,7 @@ namespace Aesthetik.WMS
 
             // Load INSetup for defaults
             var setup = SelectFrom<INSetup>.View.ReadOnly.SelectSingleBound(_graph, null);
+            // REVIEWED: extension-safe — INSetup singleton via SelectSingleBound, cache-init
             var setupExt = ((INSetup)setup)?.GetExtension<INSetupExt>();
 
             // Group by SKU for sequential serial numbering per SKU per day
@@ -453,6 +454,7 @@ namespace Aesthetik.WMS
                         status = (INLotSerialStatus)statusCache.Insert(status);
 
                         // Set extension fields
+                        // REVIEWED: extension-safe — status returned by statusCache.Insert() is explicitly cache-bound
                         var ext = status.GetExtension<INLotSerialStatusExt>();
                         ext.UsrActualYardage = line.Yardage;
                         ext.UsrDyeLot = line.DyeLot;
@@ -583,6 +585,7 @@ namespace Aesthetik.WMS
                     if (statusRecord != null)
                     {
                         var status = (INLotSerialStatus)statusRecord;
+                        // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.Select(_graph), cache-init
                         var ext = status.GetExtension<INLotSerialStatusExt>();
                         ext.UsrPreAssignedBin = targetBin.LocationCD;
 
@@ -621,6 +624,7 @@ namespace Aesthetik.WMS
                 if (status != null)
                 {
                     var s = (INLotSerialStatus)status;
+                    // REVIEWED: extension-safe — row from SelectFrom<INLotSerialStatus>.View.ReadOnly.Select(_graph), cache-init
                     var ext = s.GetExtension<INLotSerialStatusExt>();
                     serials.Add(new CreatedSerial
                     {


### PR DESCRIPTION
## Summary

- Annotates 26 instance `.GetExtension<T>()` call sites in AesthetikContainers + AesthetikWMS with the `// REVIEWED: extension-safe` marker (shipped in [acuops-pipeline#29](https://github.com/studio-b-ai/acuops-pipeline/pull/29)).
- Drops `validate-project.py` MEDIUM-risk warning count on both packages from **26 → 0**.
- Comments only. Zero code-behavior changes.

## Context

[acuops-pipeline#29](https://github.com/studio-b-ai/acuops-pipeline/pull/29) added a line-local escape hatch to the advisory Rule 2 of `validate_extension_safety`, which flags every instance `.GetExtension<T>()` call that isn't the safe static `PXCache<T>.GetExtension<>()` form.

Rule 2 exists because instance `GetExtension<>()` on records loaded outside a graph's cache (raw `PXDatabase.SelectMulti` results, serialized rows) can NRE on an uninitialized extension collection. In this codebase, every call site loads records through graph-bound views (`SelectFrom<T>.View.Select(graph, ...)`, `Base.Document.Current`, `Base.Transactions.Select()`, `statusCache.Insert()` return), which route through the cache and initialize extensions. See audit rationale in conversation preceding #29.

The refactor alternative (swap every call to `PXCache<T>.GetExtension<>()`) would touch working WMS production code — higher risk than the audit verdict justifies. Markers record the verdict next to the code.

## Files

| File | Sites | Record source pattern |
|------|-------|----------------------|
| [StudioB.Containers/Graphs/POOrderEntry_Extension.cs](src/StudioB.Containers/Graphs/POOrderEntry_Extension.cs) | 3 | `Base.Document.Current` ×2; `Base.Transactions.Select()` ×1 |
| [StudioB.WMS/Graphs/CrossDockManager.cs](src/StudioB.WMS/Graphs/CrossDockManager.cs) | 6 | `SelectSingleBound` (INSetup) ×1; `SelectFrom<INLotSerialStatus>.View.Select(Base)` ×5 |
| [StudioB.WMS/Graphs/PieceGoodsReceivingExt.cs](src/StudioB.WMS/Graphs/PieceGoodsReceivingExt.cs) | 5 | `SelectSingleBound` ×1; `SelectFrom` ×3; `statusCache.Insert()` ×1 |
| [StudioB.WMS/Graphs/SOOrderEntry_AutoAllocation.cs](src/StudioB.WMS/Graphs/SOOrderEntry_AutoAllocation.cs) | 1 | `Base.Transactions.Select()` |
| [StudioB.WMS/Graphs/TextilePickOptimizer.cs](src/StudioB.WMS/Graphs/TextilePickOptimizer.cs) | 2 | `SelectSingleBound` ×1; `SelectFrom` ×1 |
| [StudioB.WMS/Logic/CutToOrderEngine.cs](src/StudioB.WMS/Logic/CutToOrderEngine.cs) | 5 | `SelectSingleBound` ×1; `SelectFrom<INLotSerialStatus>.View.Select(_graph)` ×4 |
| [StudioB.WMS/Logic/PreReceivingEngine.cs](src/StudioB.WMS/Logic/PreReceivingEngine.cs) | 4 | `SelectSingleBound` ×1; `SelectFrom(_graph)` ×2; `statusCache.Insert()` ×1 |

## Test plan

- [x] `python3 /Users/kevin/dev/acuops-pipeline/scripts/validate-project.py --no-semantic Customization/AesthetikWMS/project.xml` → **0 MEDIUM-RISK warnings** (down from 23)
- [x] `python3 /Users/kevin/dev/acuops-pipeline/scripts/validate-project.py --no-semantic Customization/AesthetikContainers/project.xml` → **0 MEDIUM-RISK warnings** (down from 3)
- [x] Both packages PASS validation
- [x] Diff is comments-only: `git diff --shortstat` → `7 files changed, 26 insertions(+)` — no deletions, no code changes
- [ ] CI green on this branch

## Merge safety

No code changes = no app-pool restart needed for customers already on these packages. This is a pure validator-hygiene PR. Can ship in the next scheduled deploy alongside unrelated changes, or merge standalone without redeploying (marker only affects pre-deploy validation, not runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)