### PR TITLE
fix(containers): add all 12 OData GIs to GI_SCREENS_REQUIRING_GRANT[]

### DIFF
--- a/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
+++ b/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
@@ -1144,8 +1144,21 @@ namespace StudioB.Containers
         // creates the missing rows from a clean slate.
         private static readonly string[] GI_SCREENS_REQUIRING_GRANT = new[]
         {
-            "SB401120", // DRP_ItemWarehouseSettings — stuck after PR #462
-            "SB401130", // InventoryQuantityDetail   — stuck after PR #462
+            // Original container-tracking GIs (role access set by initial publish;
+            // listed here so EnsureGIRoleAccess() re-heals if ever lost)
+            "SB401000", // POContainers
+            "SB401020", // ContainerEvents
+            "SB401040", // POContainerLines
+            "SB401050", // ArrivingThisWeek
+            "SB401060", // ContainersNeedingAttention
+            "SB401070", // LandedCostSummary
+            // DRP OData GIs — stuck after PR #462 (source: EnsureGIRoleAccess fix)
+            "SB401080", // DRP_VelocityHistory
+            "SB401090", // DRP_OpenSOCommitments
+            "SB401100", // DRP_OpenPOLines
+            "SB401110", // DRP_InventoryBySite
+            "SB401120", // DRP_ItemWarehouseSettings
+            "SB401130", // InventoryQuantityDetail
         };
 
         private const string GI_GRANT_SOURCE_SCREEN = "SB401080"; // DRP_VelocityHistory


### PR DESCRIPTION
## Summary

- `GI_SCREENS_REQUIRING_GRANT[]` in `AesthetikContainersInstall.cs` only contained 2 entries (SB401120, SB401130 — the two stuck-at-403 GIs fixed in PR #462)
- The original 6 container GIs (SB401000/020/040/050/060/070) and 4 remaining DRP GIs (SB401080/090/100/110) had role-access rows from prior publishes but no self-healing protection
- If those DB rows were ever lost (tenant reset, publish failure), those GIs would silently revert to 403 with no automatic recovery
- This PR extends the array to all 12 OData-exposed screens; INSERT is idempotent (`NOT EXISTS` guard) — no risk to currently-working GIs

## Why now

The new `validate-project.py` GI OData contract guard (acuops-pipeline, companion PR) errors on any OData GI not listed in `GI_SCREENS_REQUIRING_GRANT[]`. This fix must merge before or with that guard to keep CI green.

## Test plan

- [ ] Validator passes: `python3 validate-project.py .../AesthetikContainers/project.xml --no-semantic` → 12 OData OK, 0 errors
- [ ] EnsureGIRoleAccess is idempotent: no harm on next sandbox deploy (all rows already exist, NOT EXISTS skips inserts)
- [ ] Sandbox OData probes still return 200 after next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)