### PR TITLE
feat(drp): add UsrExpArrivalDate to DRP_OpenPOLines GI (PR-2)

### DIFF
--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -2668,6 +2668,7 @@ public partial class Page_SB_SB302040 : PXPage
             </GIRelation>
             <GIResult LineNbr="10" SortOrder="10" IsActive="1" Field="UsrAcknowledgedDate" Width="110" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Vendor Ack'd" RowID="ccc39a8e-89cf-435f-8e39-c35ecd032bc6" />
             <GIResult LineNbr="11" SortOrder="11" IsActive="1" Field="UsrFactoryReadyDate" Width="110" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Factory Ready" RowID="db94eb69-50b0-468b-ac76-81f3515ce171" />
+            <GIResult LineNbr="13" SortOrder="13" IsActive="1" Field="UsrExpArrivalDate" Width="100" IsVisible="1" DefaultNav="0" QuickFilter="0" FastFilter="1" Caption="Expected Arrival" RowID="3693e617-4a1d-47bf-bf9c-d92a35096fba" />
           </GITable>
           <GITable Alias="Line" Name="PX.Objects.PO.POLine" Type="0">
             <GIRelation LineNbr="2" ChildTable="ContainerLink" IsActive="1" JoinType="L">


### PR DESCRIPTION
## Summary

PR-2 of the 2026-04-18 PO Command Center design session. Adds `UsrExpArrivalDate` as a new `<GIResult>` row to the `DRP_OpenPOLines` Generic Inquiry (SB401100) under the POOrder alias. Unblocks bolt-wms customer stock API from showing live Terminal49/OTS ETA instead of the frozen `POLine.PromisedDate` fallback.

**Ship in same after-hours co-publish as PR-5** (acumatica-ci-cd `feat/acucustom-usrfactorypromised-plus-container-twin-retirement`). Kevin will coordinate the deploy window.

## Design source of truth

- [client-asthetik/docs/po-command-center/2026-04-18-design-decisions.md](https://github.com/studio-b-ai/client-asthetik) § Block A + PR backlog row 2
- [client-asthetik/docs/po-command-center/date-model-deep-dive.md](https://github.com/studio-b-ai/client-asthetik) table row 35

## Changes

- `Customization/AesthetikContainers/project.xml` — new `<GIResult LineNbr="13" SortOrder="13" Field="UsrExpArrivalDate" Width="100" Caption="Expected Arrival" RowID="3693e617-4a1d-47bf-bf9c-d92a35096fba" />` inside the POOrder GITable of the `DRP_OpenPOLines` `<GenericInquiryScreen>` block.

## Companion PR

bolt-wms: [feat(drp): sync UsrExpArrivalDate from DRP_OpenPOLines into expected_date](https://github.com/studio-b-ai/bolt-wms/pull/new/feat/bolt-wms-drp-sync-exparrival-field)

## Rule compliance

- **Rule #17 GI Creation Contract:** modifying an existing OData-exposed GI (SB401100), not adding a new one. SB401100 already carries `<RolesInGraph Rolename="*" Accessrights="4"/>` in its SiteMap row and serves traffic at 200 on prod. No `GI_SCREENS_REQUIRING_GRANT[]` update needed.
- **Rule #24:** no `<Sql>` elements touched. `POOrder.UsrExpArrivalDate` / `POLine.UsrExpArrivalDate` already created by existing `EnsureColumn` calls in `AesthetikContainersInstall.cs`.
- **Rule #31 (GenericInquiryScreen tracking):** adding a `<GIResult>` row inside an already-applied block. Sandbox publish + OData probe before prod (field must appear in the GI response for the `UsrExpArrivalDate` column).
- **Rule #22:** co-publish list stays `AesthetikContainers + AesthetikWMS + AsthetikTheme + StudioBAcuOps` (per `acuops.yaml`). No ISV packages.

## Acceptance

- [ ] Sandbox publish succeeds
- [ ] `curl -u$USER:$PASS $URL/OData/"Heritage Fabrics"/DRP_OpenPOLines?\$top=1` returns `UsrExpArrivalDate` (or Caption-variant field) in the result set
- [ ] bolt-wms companion PR populates `drp_signal_open_po_cache.expected_date` after deploy
- [ ] Customer Stock API `incoming[].expected_date` reflects live Terminal49 ETA post-deploy

## Test plan

- [ ] `acuops-pipeline` auto-qualifier (validate-project.py + sandbox dry-run + ui-test-suite) greens on this branch
- [ ] After co-publish with PR-5, probe `DRP_OpenPOLines` OData endpoint against prod tenant
- [ ] bolt-wms unit tests pass locally (companion PR has 3 new cases covering ExpArrival / ExpectedArrival / UsrExpArrivalDate variants)

Rule #11 / Rule #19 compliance: after-hours deploy only; `skip_sandbox_gate=OVERRIDE` forbidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)