### PR TITLE
feat(containers): add UsrFactoryPromisedDate + retire UsrContainer mill-date twins (PR-5)

### DIFF
--- a/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
+++ b/Customization/AesthetikContainers/Pages/SB/SB501000.aspx
@@ -68,9 +68,9 @@
                     <px:PXGridColumn DataField="LastFreeDay" Width="90" />
                     <px:PXGridColumn DataField="DaysToLFD" Width="60" TextAlign="Right" />
                     <px:PXGridColumn DataField="DemurrageExposure" Width="100" TextAlign="Right" />
-                    <px:PXGridColumn DataField="FactoryPromisedDate" Width="90" />
-                    <px:PXGridColumn DataField="FactoryActualDate" Width="90" />
-                    <px:PXGridColumn DataField="MillAckDate" Width="90" />
+                    <%-- PR-5 2026-04-18: MillAckDate / FactoryPromisedDate / FactoryActualDate
+                         retired in favor of PO-rollups — see ContainerMaint RowSelected +
+                         ContainerTimelineBuilder for read-time aggregation. --%>
                     <px:PXGridColumn DataField="DocsSummary" Width="60" TextAlign="Center" />
                     <px:PXGridColumn DataField="PortOfDischarge" Width="90" />
                     <px:PXGridColumn DataField="LastEventCode" Width="100" />
@@ -124,9 +124,9 @@
                 <px:PXDateTimeEdit ID="edATA" runat="server" DataField="ATA" />
                 <px:PXDateTimeEdit ID="edLastFreeDay" runat="server" DataField="LastFreeDay" />
                 <px:PXNumberEdit ID="edDemurrageDailyRate" runat="server" DataField="DemurrageDailyRate" />
-                <px:PXDateTimeEdit ID="edMillAckDate" runat="server" DataField="MillAckDate" />
-                <px:PXDateTimeEdit ID="edFactoryPromisedDate" runat="server" DataField="FactoryPromisedDate" />
-                <px:PXDateTimeEdit ID="edFactoryActualDate" runat="server" DataField="FactoryActualDate" />
+                <%-- PR-5 2026-04-18: MillAckDate / FactoryPromisedDate / FactoryActualDate
+                     retired. See DAC comment in UsrContainer.cs + ContainerTimelineBuilder
+                     for the new PO-rollup read pattern. --%>
                 <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
                 <px:PXDateTimeEdit ID="edFactoryPickupDate" runat="server" DataField="FactoryPickupDate" />
                 <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />

--- a/Customization/AesthetikContainers/project.xml
+++ b/Customization/AesthetikContainers/project.xml
@@ -284,9 +284,9 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                     <px:PXGridColumn DataField="LastFreeDay" Width="90" />
                     <px:PXGridColumn DataField="DaysToLFD" Width="60" TextAlign="Right" />
                     <px:PXGridColumn DataField="DemurrageExposure" Width="100" TextAlign="Right" />
-                    <px:PXGridColumn DataField="FactoryPromisedDate" Width="90" />
-                    <px:PXGridColumn DataField="FactoryActualDate" Width="90" />
-                    <px:PXGridColumn DataField="MillAckDate" Width="90" />
+                    <%-- PR-5 2026-04-18: MillAckDate / FactoryPromisedDate / FactoryActualDate
+                         retired in favor of PO-rollups — see ContainerMaint RowSelected +
+                         ContainerTimelineBuilder for read-time aggregation. --%>
                     <px:PXGridColumn DataField="DocsSummary" Width="60" TextAlign="Center" />
                     <px:PXGridColumn DataField="PortOfDischarge" Width="90" />
                     <px:PXGridColumn DataField="LastEventCode" Width="100" />
@@ -340,9 +340,9 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('POOrder') 
                 <px:PXDateTimeEdit ID="edATA" runat="server" DataField="ATA" />
                 <px:PXDateTimeEdit ID="edLastFreeDay" runat="server" DataField="LastFreeDay" />
                 <px:PXNumberEdit ID="edDemurrageDailyRate" runat="server" DataField="DemurrageDailyRate" />
-                <px:PXDateTimeEdit ID="edMillAckDate" runat="server" DataField="MillAckDate" />
-                <px:PXDateTimeEdit ID="edFactoryPromisedDate" runat="server" DataField="FactoryPromisedDate" />
-                <px:PXDateTimeEdit ID="edFactoryActualDate" runat="server" DataField="FactoryActualDate" />
+                <%-- PR-5 2026-04-18: MillAckDate / FactoryPromisedDate / FactoryActualDate
+                     retired. See DAC comment in UsrContainer.cs + ContainerTimelineBuilder
+                     for the new PO-rollup read pattern. --%>
                 <px:PXDateTimeEdit ID="edCargoReadyDate" runat="server" DataField="CargoReadyDate" />
                 <px:PXDateTimeEdit ID="edFactoryPickupDate" runat="server" DataField="FactoryPickupDate" />
                 <px:PXDateTimeEdit ID="edOnBoardDate" runat="server" DataField="OnBoardDate" />

--- a/publish-manifest.json
+++ b/publish-manifest.json
@@ -3,7 +3,7 @@
   "entities": {
     "PurchaseOrder": {
       "screen": "PO301000",
-      "custom_fields": ["custom.Document.UsrExpArrivalDate", "custom.Document.UsrActArrivalDate", "custom.Document.UsrContainerRef"]
+      "custom_fields": ["custom.Document.UsrExpArrivalDate", "custom.Document.UsrActArrivalDate", "custom.Document.UsrContainerRef", "custom.Document.UsrFactoryPromisedDate"]
     },
     "SalesOrder": {
       "screen": "SO301000",
@@ -41,7 +41,7 @@
     },
     {
       "entity": "PurchaseOrder",
-      "select_fields": ["OrderNbr", "UsrExpArrivalDate", "UsrActArrivalDate", "UsrContainerRef"]
+      "select_fields": ["OrderNbr", "UsrExpArrivalDate", "UsrActArrivalDate", "UsrContainerRef", "UsrFactoryPromisedDate"]
     },
     {
       "entity": "StockItem",
@@ -57,8 +57,8 @@
     }
   ],
   "sql_columns": [
-    {"table": "POOrder", "columns": ["UsrExpArrivalDate", "UsrActArrivalDate", "UsrContainerRef"]},
-    {"table": "POLine", "columns": ["UsrExpArrivalDate", "UsrActArrivalDate"]},
+    {"table": "POOrder", "columns": ["UsrExpArrivalDate", "UsrActArrivalDate", "UsrContainerRef", "UsrFactoryPromisedDate"]},
+    {"table": "POLine", "columns": ["UsrExpArrivalDate", "UsrActArrivalDate", "UsrFactoryPromisedDate"]},
     {"table": "SOOrder", "columns": ["UsrHubSpotDealId"]},
     {"table": "BAccount", "columns": ["UsrDisablePayLink", "UsrDefaultInTransitSiteID", "UsrDefaultCarrierCode"]},
     {"table": "InventoryItem", "columns": ["UsrHTSCode", "UsrDutyRate", "UsrCountryOfOrigin", "UsrFiberContent", "UsrPreferentialTariff", "UsrFreightClass"]},

--- a/src/StudioB.Containers/DACs/UsrContainer.cs
+++ b/src/StudioB.Containers/DACs/UsrContainer.cs
@@ -532,28 +532,17 @@ namespace StudioB.Containers
         #endregion
         // --- end 2026-04-12 additions ---
 
-        // --- 2026-04-11: PCC redesign — Mill date fields ---
-        #region MillAckDate
-        public abstract class millAckDate : BqlDateTime.Field<millAckDate> { }
-        [PXDBDate(PreserveTime = true)]
-        [PXUIField(DisplayName = "Mill Ack Date")]
-        public DateTime? MillAckDate { get; set; }
-        #endregion
-
-        #region FactoryPromisedDate
-        public abstract class factoryPromisedDate : BqlDateTime.Field<factoryPromisedDate> { }
-        [PXDBDate]
-        [PXUIField(DisplayName = "Factory Promised")]
-        public DateTime? FactoryPromisedDate { get; set; }
-        #endregion
-
-        #region FactoryActualDate
-        public abstract class factoryActualDate : BqlDateTime.Field<factoryActualDate> { }
-        [PXDBDate]
-        [PXUIField(DisplayName = "Factory Actual")]
-        public DateTime? FactoryActualDate { get; set; }
-        #endregion
-        // --- end 2026-04-11 mill date fields ---
+        // --- 2026-04-18: PR-5 — retired mill date fields ---
+        // MillAckDate, FactoryPromisedDate, FactoryActualDate retired
+        // in favor of PO-level rollups from linked POs via
+        // UsrContainerPOLink. See ContainerTimelineBuilder /
+        // ContainerMaint for the read-time aggregation:
+        //   - ACKED stage actual      = MIN(POOrderExt.UsrAcknowledgedDate)
+        //   - FACTORY READY actual    = MAX(POOrderExt.UsrFactoryReadyDate)
+        //   - FACTORY PROMISED (est.) = MAX(POOrderExt.UsrFactoryPromisedDate)
+        // Per design-decisions.md Block A.2 + date-model-deep-dive.md.
+        // Columns dropped via AesthetikContainersInstall.DropColumn().
+        // --- end 2026-04-18 retirement ---
 
         #region NoteID
         public abstract class noteID : BqlGuid.Field<noteID> { }

--- a/src/StudioB.Containers/Extensions/POLineExt.cs
+++ b/src/StudioB.Containers/Extensions/POLineExt.cs
@@ -20,6 +20,12 @@ namespace StudioB.Containers
         [PXUIField(DisplayName = "Act. Arrival Date")]
         public DateTime? UsrActArrivalDate { get; set; }
         #endregion
+        #region UsrFactoryPromisedDate
+        public abstract class usrFactoryPromisedDate : BqlDateTime.Field<usrFactoryPromisedDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Factory Promised Ready Date")]
+        public DateTime? UsrFactoryPromisedDate { get; set; }
+        #endregion
         #region UsrQtyOnContainers
         public abstract class usrQtyOnContainers : PX.Data.BQL.BqlDecimal.Field<usrQtyOnContainers> { }
         /// <summary>

--- a/src/StudioB.Containers/Extensions/POOrderExt.cs
+++ b/src/StudioB.Containers/Extensions/POOrderExt.cs
@@ -38,5 +38,11 @@ namespace StudioB.Containers
         [PXUIField(DisplayName = "Factory Ready Date")]
         public DateTime? UsrFactoryReadyDate { get; set; }
         #endregion
+        #region UsrFactoryPromisedDate
+        public abstract class usrFactoryPromisedDate : BqlDateTime.Field<usrFactoryPromisedDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Factory Promised Ready Date")]
+        public DateTime? UsrFactoryPromisedDate { get; set; }
+        #endregion
     }
 }

--- a/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
+++ b/src/StudioB.Containers/Graphs/AesthetikContainersInstall.cs
@@ -100,10 +100,17 @@ namespace StudioB.Containers
                     EnsureColumn(conn, "UsrContainer", "SCACNumber",             "nvarchar(10) NULL");
                     EnsureColumn(conn, "UsrContainer", "EstimatedFreight",       "decimal(19,4) NULL");
 
-                    // 2026-04-11: PCC redesign — mill date fields
-                    EnsureColumn(conn, "UsrContainer", "MillAckDate",          "datetime NULL");
-                    EnsureColumn(conn, "UsrContainer", "FactoryPromisedDate",  "datetime NULL");
-                    EnsureColumn(conn, "UsrContainer", "FactoryActualDate",    "datetime NULL");
+                    // 2026-04-18: PR-5 UsrContainer mill-date field retirement.
+                    // MillAckDate / FactoryPromisedDate / FactoryActualDate are
+                    // retired in favor of PO-level rollups from the new
+                    // POOrderExt.UsrFactoryPromisedDate + existing
+                    // UsrAcknowledgedDate / UsrFactoryReadyDate (see
+                    // design-decisions.md Block A.2, PR-5). Drop the columns
+                    // so consumers can't silently drift on stale data.
+                    // Idempotent: IF EXISTS before DROP.
+                    DropColumn(conn, "UsrContainer", "MillAckDate");
+                    DropColumn(conn, "UsrContainer", "FactoryPromisedDate");
+                    DropColumn(conn, "UsrContainer", "FactoryActualDate");
 
                     // 2026-04-12: PCC usability — receipt tracking
                     EnsureColumn(conn, "UsrContainer", "ReceiptNbr", "nvarchar(30) NULL");
@@ -264,6 +271,12 @@ namespace StudioB.Containers
                     EnsureColumn(conn, "POOrder", "UsrContainerRef",   "nvarchar(50) NULL");
                     EnsureColumn(conn, "POOrder", "UsrAcknowledgedDate", "datetime NULL");
                     EnsureColumn(conn, "POOrder", "UsrFactoryReadyDate", "datetime NULL");
+                    // 2026-04-18: PR-5 — factory's production commitment date
+                    // stamped at vendor acknowledgment (email parser). Distinct
+                    // from UsrFactoryReadyDate (actual ready) — enables the
+                    // production-commitment-adherence scorecard metric.
+                    EnsureColumn(conn, "POLine",  "UsrFactoryPromisedDate", "datetime NULL");
+                    EnsureColumn(conn, "POOrder", "UsrFactoryPromisedDate", "datetime NULL");
 
                     // ── BAccount vendor defaults ─────────────────────────────
                     EnsureColumn(conn, "BAccount", "UsrDefaultInTransitSiteID", "int NULL");
@@ -475,6 +488,31 @@ namespace StudioB.Containers
                 table, column, definition);
             using (var cmd = new SqlCommand(sql, conn)) { cmd.ExecuteNonQuery(); }
             WriteLog(string.Format("  Column {0}.{1} — OK", table, column));
+        }
+
+        /// <summary>
+        /// Idempotently drop a column if it exists.
+        /// Used for retiring DAC fields during cleanup (PR-5, 2026-04-18).
+        /// Drops any default constraint first — SQL Server refuses DROP COLUMN
+        /// when a bound default exists.
+        /// </summary>
+        private void DropColumn(SqlConnection conn, string table, string column)
+        {
+            string sql = string.Format(@"
+                IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('{0}') AND name = '{1}')
+                BEGIN
+                    DECLARE @constraint_name nvarchar(200);
+                    SELECT @constraint_name = dc.name
+                      FROM sys.default_constraints dc
+                      JOIN sys.columns c ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+                     WHERE dc.parent_object_id = OBJECT_ID('{0}')
+                       AND c.name = '{1}';
+                    IF @constraint_name IS NOT NULL
+                        EXEC('ALTER TABLE [{0}] DROP CONSTRAINT [' + @constraint_name + '];');
+                    ALTER TABLE [{0}] DROP COLUMN [{1}];
+                END;", table, column);
+            using (var cmd = new SqlCommand(sql, conn)) { cmd.ExecuteNonQuery(); }
+            WriteLog(string.Format("  Column {0}.{1} — DROPPED (if existed)", table, column));
         }
 
         private void EnsureTable(SqlConnection conn, string table, string columnDefs)

--- a/src/StudioB.Containers/Graphs/ContainerMaint.cs
+++ b/src/StudioB.Containers/Graphs/ContainerMaint.cs
@@ -250,6 +250,12 @@ namespace StudioB.Containers
         /// Counts of docs and ETA history are skipped here (set to 0) — they'd cost a query
         /// per container which is too expensive at list time. Full risk level lands during
         /// RowSelected for the currently displayed rows.
+        ///
+        /// 2026-04-18 PR-5: factory-promised / factory-actual inputs passed as null
+        /// here since container-level twins were retired. Those constraints now
+        /// come from PO-rollups which are too expensive to recompute per-row at
+        /// list time — the full-detail RowSelected path still applies them
+        /// (see DoTabsAndTimeline).
         /// </summary>
         private string ComputeRiskLevelInline(UsrContainer row, DateTime today)
         {
@@ -265,8 +271,8 @@ namespace StudioB.Containers
                 docsReceived: 0,
                 etaChangesLast7Days: 0,
                 customsHoldDays: customsHoldDays,
-                factoryPromisedDate: row.FactoryPromisedDate,
-                factoryActualDate: row.FactoryActualDate);
+                factoryPromisedDate: null,
+                factoryActualDate: null);
         }
         #endregion
 
@@ -935,12 +941,14 @@ namespace StudioB.Containers
                 // --- Tile 1: LATE ---
                 bool isLate = false;
 
-                if (c.FactoryPromisedDate.HasValue && c.FactoryPromisedDate.Value.Date < today.Date
-                    && !c.FactoryActualDate.HasValue)
-                {
-                    tile.LateFactoryOverdue++;
-                    isLate = true;
-                }
+                // 2026-04-18 PR-5: LateFactoryOverdue tile previously checked
+                // container-level FactoryPromisedDate/FactoryActualDate which
+                // were retired in favor of PO-rollups. Restoring this metric
+                // via PO-rollup requires a separate batch query per dashboard
+                // render (one SQL for all active containers' max UsrFactoryPromisedDate
+                // + max UsrFactoryReadyDate across linked POs); tracked for the
+                // PR-7 vendor scorecard dashboard work. For now the tile
+                // increments from PastETA / PastLFD / CustomsHold signals only.
                 if (c.ETA.HasValue && c.ETA.Value.Date < today.Date && !c.ATA.HasValue
                     && status != ContainerStatus.Delivered && status != ContainerStatus.Cancelled)
                 {
@@ -1088,26 +1096,20 @@ namespace StudioB.Containers
                 }
             }
 
-            row.RiskLevel = ContainerRiskCalculator.ComputeRiskLevel(
-                today, row.Status, row.LastFreeDay, row.ETA, row.ISFFiledDate, row.DepartedDate,
-                docsRequired, docsReceived, etaChanges, holdDays,
-                factoryPromisedDate: row.FactoryPromisedDate,
-                factoryActualDate: row.FactoryActualDate);
-
-            if (row.LastFreeDay.HasValue)
-                row.DaysToLFD = (int)(row.LastFreeDay.Value.Date - today.Date).TotalDays;
-            else
-                row.DaysToLFD = null;
-
-            row.DemurrageExposure = ContainerRiskCalculator.ComputeDemurrageExposure(
-                today, row.LastFreeDay, row.DemurrageDailyRate,
-                holdDays, customsHoldEstimatedCostPerDay: null);
-
             // --- Phase D: Timeline strip + tab count aggregation ---
-            // PO date aggregates for hybrid timeline (hoisted for timeline build below)
+            // Hoisted ABOVE ComputeRiskLevel / timeline build so the PO rollups
+            // are available to both. 2026-04-18 PR-5:
+            //   earliestOrderDate         = MIN(POOrder.OrderDate)              — when the first PO was placed
+            //   firstAckedDate            = MIN(POOrderExt.UsrAcknowledgedDate) — first ack (per design-decisions A.2)
+            //   latestFactoryReadyDate    = MAX(POOrderExt.UsrFactoryReadyDate) — container ships when slowest PO is ready
+            //   latestFactoryPromisedDate = MAX(POOrderExt.UsrFactoryPromisedDate) — production commitment estimate
+            // Container-level MillAckDate / FactoryPromisedDate / FactoryActualDate
+            // columns retired in this PR — all stage 1-2 data now comes from the
+            // PO rollups below, and the risk calculator consumes the same values.
             DateTime? earliestOrderDate = null;
-            DateTime? latestAckedDate = null;
+            DateTime? firstAckedDate = null;
             DateTime? latestFactoryReadyDate = null;
+            DateTime? latestFactoryPromisedDate = null;
 
             if (row.ContainerID.HasValue)
             {
@@ -1143,10 +1145,18 @@ namespace StudioB.Containers
                         if (po.OrderDate.HasValue && (!earliestOrderDate.HasValue || po.OrderDate.Value < earliestOrderDate.Value))
                             earliestOrderDate = po.OrderDate;
                         var poExt = PXCache<POOrder>.GetExtension<POOrderExt>(po);
-                        if (poExt?.UsrAcknowledgedDate != null && (!latestAckedDate.HasValue || poExt.UsrAcknowledgedDate.Value > latestAckedDate.Value))
-                            latestAckedDate = poExt.UsrAcknowledgedDate;
+                        // First-ack (MIN) per design-decisions.md A.2 — a container's
+                        // ACK milestone lands when the first vendor confirms.
+                        if (poExt?.UsrAcknowledgedDate != null && (!firstAckedDate.HasValue || poExt.UsrAcknowledgedDate.Value < firstAckedDate.Value))
+                            firstAckedDate = poExt.UsrAcknowledgedDate;
+                        // Latest-ready (MAX) — container can't ship until the
+                        // slowest PO is ready (all lines packed into the container).
                         if (poExt?.UsrFactoryReadyDate != null && (!latestFactoryReadyDate.HasValue || poExt.UsrFactoryReadyDate.Value > latestFactoryReadyDate.Value))
                             latestFactoryReadyDate = poExt.UsrFactoryReadyDate;
+                        // Latest-promised (MAX) — promised ready for the container
+                        // equals the slowest PO's promised date (same reason as above).
+                        if (poExt?.UsrFactoryPromisedDate != null && (!latestFactoryPromisedDate.HasValue || poExt.UsrFactoryPromisedDate.Value > latestFactoryPromisedDate.Value))
+                            latestFactoryPromisedDate = poExt.UsrFactoryPromisedDate;
                     }
                 }
                 row.POLinksCount = poLinksCount;
@@ -1174,19 +1184,34 @@ namespace StudioB.Containers
                 row.CostsTotal = 0m;
             }
 
-            // Build the timeline HTML for the selected row
+            row.RiskLevel = ContainerRiskCalculator.ComputeRiskLevel(
+                today, row.Status, row.LastFreeDay, row.ETA, row.ISFFiledDate, row.DepartedDate,
+                docsRequired, docsReceived, etaChanges, holdDays,
+                factoryPromisedDate: latestFactoryPromisedDate,
+                factoryActualDate: latestFactoryReadyDate);
+
+            if (row.LastFreeDay.HasValue)
+                row.DaysToLFD = (int)(row.LastFreeDay.Value.Date - today.Date).TotalDays;
+            else
+                row.DaysToLFD = null;
+
+            row.DemurrageExposure = ContainerRiskCalculator.ComputeDemurrageExposure(
+                today, row.LastFreeDay, row.DemurrageDailyRate,
+                holdDays, customsHoldEstimatedCostPerDay: null);
+
+            // Build the timeline HTML for the selected row.
+            // 2026-04-18 PR-5: all mill-date inputs now come from PO rollups
+            // (container-level twins retired — see UsrContainer.cs +
+            // design-decisions.md Block A.2).
             row.TimelineHtml = ContainerTimelineBuilder.Build(new ContainerTimelineBuilder.TimelineData
             {
                 Status = row.Status,
-                // PO-sourced dates (hybrid timeline)
+                // PO-sourced rollups (stages 1-3)
                 OrderDate = earliestOrderDate,
-                AcknowledgedDate = latestAckedDate,
+                AcknowledgedDate = firstAckedDate,
                 FactoryReadyDate = latestFactoryReadyDate,
-                // Container-level mill/factory dates
-                FactoryPromisedDate = row.FactoryPromisedDate,
-                FactoryActualDate = row.FactoryActualDate,
-                MillAckDate = row.MillAckDate,
-                // Container-sourced dates
+                FactoryPromisedDate = latestFactoryPromisedDate,
+                // Container-sourced dates (stages 4-8)
                 BookedDate = row.BookedDate,
                 DepartedDate = row.DepartedDate,
                 ArrivedPortDate = row.ArrivedPortDate,

--- a/src/StudioB.Containers/Graphs/ContainerTimelineBuilder.cs
+++ b/src/StudioB.Containers/Graphs/ContainerTimelineBuilder.cs
@@ -12,21 +12,33 @@ namespace StudioB.Containers
     ///   PLACED → ACKED → FACTORY READY → SHIPPED → IN TRANSIT →
     ///   ARRIVED PORT → CUSTOMS → DELIVERED
     ///
-    /// First 3 sourced from linked PO dates, last 5 from container events.
+    /// First 3 sourced from linked PO date rollups (via UsrContainerPOLink —
+    /// see ContainerMaint.DoTabsAndTimeline), last 5 from container events.
     /// Each cell shows one of three states:
     ///   complete — milestone has a real timestamp (green check)
     ///   active   — current state (colored marker)
     ///   pending  — not yet reached (gray)
+    ///
+    /// 2026-04-18 PR-5: container-level mill-date columns (MillAckDate /
+    /// FactoryPromisedDate / FactoryActualDate) retired. Stage 1-2 dates
+    /// now come from PO-rollup values only — caller aggregates across
+    /// linked POs and passes the results here.
     /// </summary>
     public static class ContainerTimelineBuilder
     {
         public struct TimelineData
         {
             public string Status;
-            // PO-sourced dates (first 3 stages)
-            public DateTime? OrderDate;          // PLACED — earliest linked PO OrderDate
-            public DateTime? AcknowledgedDate;   // ACKED — latest linked PO UsrAcknowledgedDate
-            public DateTime? FactoryReadyDate;   // FACTORY READY — latest linked PO UsrFactoryReadyDate
+            // PO-sourced dates (first 3 stages) — caller aggregates across
+            // linked POs via UsrContainerPOLink:
+            //   OrderDate           = MIN(POOrder.OrderDate)
+            //   AcknowledgedDate    = MIN(POOrderExt.UsrAcknowledgedDate)      [first ack]
+            //   FactoryReadyDate    = MAX(POOrderExt.UsrFactoryReadyDate)      [slowest wins]
+            //   FactoryPromisedDate = MAX(POOrderExt.UsrFactoryPromisedDate)   [commitment estimate]
+            public DateTime? OrderDate;
+            public DateTime? AcknowledgedDate;
+            public DateTime? FactoryReadyDate;
+            public DateTime? FactoryPromisedDate;  // NEW — rollup from POOrderExt.UsrFactoryPromisedDate
             // Container-sourced dates (last 5 stages)
             public DateTime? DepartedDate;       // SHIPPED
             public DateTime? ArrivedPortDate;    // ARRIVED PORT
@@ -36,10 +48,6 @@ namespace StudioB.Containers
             public DateTime? ETA;
             public DateTime? ATA;
             public int? CustomsHoldDays;
-            // Container-level mill/factory dates (preferred over PO-sourced)
-            public DateTime? FactoryPromisedDate;  // Mill's promised ready date
-            public DateTime? FactoryActualDate;    // When goods were actually ready
-            public DateTime? MillAckDate;          // When mill acknowledged
             // Legacy — kept for backwards compat but no longer drives a stop
             public DateTime? BookedDate;
         }
@@ -105,12 +113,12 @@ namespace StudioB.Containers
         private static Stop[] BuildStops(TimelineData d)
         {
             var stops = new Stop[8];
-            // PO-sourced stages
+            // PO-sourced stages — all PO rollups now (container-level twins retired)
             stops[0] = new Stop { Key = "PLACED",    Label = "PLACED",        ActualDate = d.OrderDate };
-            stops[1] = new Stop { Key = "ACKED",     Label = "ACKED",         ActualDate = d.MillAckDate ?? d.AcknowledgedDate };
+            stops[1] = new Stop { Key = "ACKED",     Label = "ACKED",         ActualDate = d.AcknowledgedDate };
             stops[2] = new Stop {
                 Key = "FACTORY", Label = "FACTORY READY",
-                ActualDate = d.FactoryActualDate ?? d.FactoryReadyDate,
+                ActualDate = d.FactoryReadyDate,
                 EstimatedDate = d.FactoryPromisedDate,
                 SecondaryDate = d.FactoryPromisedDate,
             };
@@ -159,8 +167,9 @@ namespace StudioB.Containers
             }
 
             // Special case: FACTORY READY — if actual > promised, mark as alert (was late)
-            if (d.FactoryActualDate.HasValue && d.FactoryPromisedDate.HasValue &&
-                d.FactoryActualDate.Value.Date > d.FactoryPromisedDate.Value.Date)
+            // Actual = MAX(UsrFactoryReadyDate) rollup; Promised = MAX(UsrFactoryPromisedDate)
+            if (d.FactoryReadyDate.HasValue && d.FactoryPromisedDate.HasValue &&
+                d.FactoryReadyDate.Value.Date > d.FactoryPromisedDate.Value.Date)
             {
                 stops[2].IsAlert = true;
             }

--- a/src/StudioB.Containers/Graphs/POOrderEntry_Extension.cs
+++ b/src/StudioB.Containers/Graphs/POOrderEntry_Extension.cs
@@ -26,10 +26,19 @@ namespace StudioB.Containers
         //                         the Transactions.Update() calls inside the header
         //                         propagation loop would re-enter RowSelected for
         //                         every line on every update.
+        //
+        //  _isProcessingFactoryPromisedLine / Header — dedicated guards for the
+        //                         2026-04-18 PR-5 UsrFactoryPromisedDate cascade.
+        //                         Kept separate from the UsrExpArrivalDate guards
+        //                         so propagating one date doesn't suppress the
+        //                         other mid-flight (possible if a header edit
+        //                         sets both dates in one transaction).
         // ────────────────────────────────────────────────────────────────────────
-        private bool _isProcessingLine        = false;
-        private bool _isProcessingHeader      = false;
-        private bool _isProcessingRowSelected = false;
+        private bool _isProcessingLine                  = false;
+        private bool _isProcessingHeader                = false;
+        private bool _isProcessingRowSelected           = false;
+        private bool _isProcessingFactoryPromisedLine   = false;
+        private bool _isProcessingFactoryPromisedHeader = false;
 
         #region Container Navigation Action
         public PXAction<POOrder> ViewContainer;
@@ -184,6 +193,75 @@ namespace StudioB.Containers
             finally
             {
                 _isProcessingHeader = false;
+            }
+        }
+
+        // ── UsrFactoryPromisedDate cascade (PR-5, 2026-04-18) ──────────────────
+        // Mirrors UsrExpArrivalDate pattern: header default cascades to line
+        // default; inherited lines stay inherited until manually overridden.
+        // Re-entrancy guarded with dedicated flags so one cascade doesn't
+        // suppress the other when both dates change in one transaction.
+
+        /// <summary>
+        /// Defaults UsrFactoryPromisedDate for a new PO line.
+        /// Priority: header UsrFactoryPromisedDate → leave blank.
+        /// </summary>
+        protected void _(Events.FieldDefaulting<POLine, POLineExt.usrFactoryPromisedDate> e)
+        {
+            if (_isProcessingFactoryPromisedLine) return;
+            if (e.Row == null) return;
+
+            POOrder header = Base.Document.Current;
+            if (header == null) return;
+
+            POOrderExt headerExt = header.GetExtension<POOrderExt>();
+            if (headerExt?.UsrFactoryPromisedDate != null)
+            {
+                e.NewValue = headerExt.UsrFactoryPromisedDate;
+                e.Cancel = true;
+            }
+            // No fallback to PromisedDate — FactoryPromisedDate is the vendor's
+            // production commitment, not the PO-level delivery promise. Leave
+            // blank when header is unset; email parser populates from vendor
+            // acknowledgment message.
+        }
+
+        /// <summary>
+        /// When the header-level UsrFactoryPromisedDate changes, propagate it down
+        /// to all lines whose factory-promised date is still "inherited" (null,
+        /// or equal to the old header value).
+        /// </summary>
+        protected void _(Events.FieldUpdated<POOrder, POOrderExt.usrFactoryPromisedDate> e)
+        {
+            if (_isProcessingFactoryPromisedHeader) return;
+            if (e.Row == null) return;
+
+            DateTime? oldValue = (DateTime?)e.OldValue;
+            DateTime? newValue = e.Row.GetExtension<POOrderExt>()?.UsrFactoryPromisedDate;
+            if (newValue == null) return;
+            if (oldValue == newValue) return;
+
+            _isProcessingFactoryPromisedHeader = true;
+            try
+            {
+                foreach (POLine line in Base.Transactions.Select())
+                {
+                    if (line == null) continue;
+                    POLineExt lineExt = line.GetExtension<POLineExt>();
+                    if (lineExt == null) continue;
+
+                    bool isInherited = lineExt.UsrFactoryPromisedDate == null
+                                    || lineExt.UsrFactoryPromisedDate == oldValue;
+                    if (isInherited)
+                    {
+                        lineExt.UsrFactoryPromisedDate = newValue;
+                        Base.Transactions.Update(line);
+                    }
+                }
+            }
+            finally
+            {
+                _isProcessingFactoryPromisedHeader = false;
             }
         }
 


### PR DESCRIPTION
## Summary

PR-5 of the 2026-04-18 PO Command Center design session. Introduces `POOrderExt.UsrFactoryPromisedDate` / `POLineExt.UsrFactoryPromisedDate` as the vendor's production-commitment date (stamped at ack time by the email parser) and retires the container-level mill-date twins (`UsrContainer.MillAckDate` / `FactoryPromisedDate` / `FactoryActualDate`) in favor of PO-rollup computation at read time.

**Ship in same after-hours co-publish as PR-2** (acumatica-ci-cd [#468](https://github.com/studio-b-ai/acumatica-ci-cd/pull/468)). Kevin will coordinate the deploy window.

## Decision on `UsrContainer.FactoryPromisedDate`

**RETIRED** (default path per task spec). No imports-workflow doc or ASPX comment references it as a container-level logistics override; no override use-case found. Aligned with `MillAckDate` / `FactoryActualDate` siblings — all computed as `MAX(POOrderExt.UsrFactoryPromisedDate)` across linked POs at read time.

## Design source of truth

- [client-asthetik/docs/po-command-center/2026-04-18-design-decisions.md](https://github.com/studio-b-ai/client-asthetik) Block A.2 + Block F.14 + PR backlog row 5
- [client-asthetik/docs/po-command-center/date-model-deep-dive.md](https://github.com/studio-b-ai/client-asthetik) \"Container twin retirement\" + Block A.2 table

## Changes (10 files, +245/-94)

1. **POOrderExt.cs / POLineExt.cs** — new `UsrFactoryPromisedDate` field (`DateTime?`, `[PXDBDate]`, `[PXUIField DisplayName=\"Factory Promised Ready Date\"]`).

2. **POOrderEntry_Extension.cs** — header→line cascade handlers (`FieldDefaulting<POLine>` + `FieldUpdated<POOrder>`) mirroring the `UsrExpArrivalDate` pattern. **Dedicated re-entrancy guards** (`_isProcessingFactoryPromisedLine` / `Header`) so the two date cascades don't suppress each other mid-transaction. No `PromisedDate` fallback — factory-promised is a production commitment distinct from delivery promise.

3. **AesthetikContainersInstall.cs**:
   - `EnsureColumn` adds for `POLine.UsrFactoryPromisedDate` + `POOrder.UsrFactoryPromisedDate` (per **Rule #24** — no `<Sql>` elements, use `CustomizationPlugin`).
   - New `DropColumn` helper (idempotent, drops bound default constraint first) + drops `MillAckDate` / `FactoryPromisedDate` / `FactoryActualDate` from `UsrContainer`.

4. **UsrContainer.cs** — remove the 3 retired DAC field definitions. Pointer comment to the PO-rollup read pattern in `ContainerMaint` + timeline builder.

5. **SB501000.aspx** — remove grid columns + detail-panel edits for the retired fields. `sync-aspx-cdata.py` re-run to refresh CDATA in `project.xml` (**Rule #14**).

6. **ContainerTimelineBuilder.cs** — drop `MillAckDate` / `FactoryActualDate` from `TimelineData`; add `FactoryPromisedDate` as a first-class input (estimate for FACTORY READY stage). ACKED / FACTORY READY stops now use PO rollups directly. Late check compares `MAX(UsrFactoryReadyDate)` vs `MAX(UsrFactoryPromisedDate)`.

7. **ContainerMaint.cs**:
   - Hoisted PO-link aggregation block **above** `ComputeRiskLevel` so rollups feed both the risk calculator and the timeline builder.
   - `firstAckedDate = MIN(UsrAcknowledgedDate)` per design-decisions A.2 (container's ACK lands when the first vendor confirms).
   - `latestFactoryReadyDate = MAX(UsrFactoryReadyDate)` (container can't ship until slowest PO is ready).
   - `latestFactoryPromisedDate = MAX(UsrFactoryPromisedDate)`.
   - **LateFactoryOverdue tile** in dashboard KPI loop gated — per-container PO rollup in a dashboard-wide loop would be too expensive; restoration via single batch SQL tracked as PR-7 follow-up. Other lateness signals still feed the tile.
   - `ComputeRiskLevelInline` (filter delegate) passes `null` for factory-promised/actual — comment documents the full-detail RowSelected path still applies them.

8. **publish-manifest.json** — adds `UsrFactoryPromisedDate` to `PurchaseOrder` `select_fields` + `custom_fields`, `POOrder` + `POLine` `sql_columns`.

## Companion PR

acumatica-ci-cd: [#468 feat(drp): add UsrExpArrivalDate to DRP_OpenPOLines GI (PR-2)](https://github.com/studio-b-ai/acumatica-ci-cd/pull/468)

## Rule compliance

- **Rule #17 GI Creation Contract:** no new OData-exposed GI in this PR. `UsrFactoryPromisedDate` is a DAC field; its GI exposure (for the vendor scorecard) lands in PR-7. `GI_SCREENS_REQUIRING_GRANT[]` untouched.
- **Rule #24:** ALTER TABLE via `EnsureColumn` / `DropColumn` in the `CustomizationPlugin`. No `<Sql>` elements.
- **Rule #31:** no `<GenericInquiryScreen>` blocks touched.
- **Rule #22:** co-publish list stays `AesthetikContainers + AesthetikWMS + AsthetikTheme + StudioBAcuOps` (per `acuops.yaml`). No ISV packages.
- **Rule #11 / Rule #19:** after-hours deploy only; `skip_sandbox_gate=OVERRIDE` forbidden.

## Acceptance

- [ ] Sandbox publish succeeds
- [ ] `UsrFactoryPromisedDate` visible on PO301000 header + detail grid; cascades from header to new lines; propagates to inherited lines when header changes
- [ ] REST API exposes `UsrFactoryPromisedDate` on PurchaseOrder entity
- [ ] `UsrContainer.MillAckDate` / `FactoryPromisedDate` / `FactoryActualDate` columns dropped successfully (verify via SQL query against sandbox)
- [ ] SB501000 ContainerTimeline renders correctly on a container with 2+ linked POs — FACTORY READY shows `MAX(UsrFactoryReadyDate)` actual and `MAX(UsrFactoryPromisedDate)` estimate
- [ ] `acuops-pipeline` auto-qualifier greens
- [ ] Existing Playwright UI tests pass (Container Mission Control + PO Command Center)

## Test plan

- [x] StudioB.Containers.Tests .NET xUnit suite: **47/47 passing** (ContainerRiskCalculator + ContainerTimelineBuilder compile + behave correctly with new TimelineData shape)
- [x] `validate-project.py --strict` on AesthetikContainers: PASSED (30 pre-existing WARN, 0 ERROR)
- [ ] Sandbox: exercise PO301000 entry — set header `UsrFactoryPromisedDate`, confirm cascade to new line and inherited-line propagation
- [ ] Sandbox: load SB501000 against a container with linked POs, verify timeline renders + tab labels correct + no regressions on existing date columns
- [ ] Post-deploy prod: `SELECT OBJECT_ID('UsrContainer'), COL_LENGTH('UsrContainer', 'MillAckDate')` — column should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)